### PR TITLE
fix(io): materialize a store ROOT for subpath reads

### DIFF
--- a/src/expr/vm/builtins/io.zig
+++ b/src/expr/vm/builtins/io.zig
@@ -91,6 +91,14 @@ pub fn demandPathArg(self: *VM, arg: Value) ![]const u8 {
         return path;
     }
 
+    // Recipes are keyed by the store root, so a subpath materializes its
+    // root; deferred hashed fetches were handled above from the full path.
+    const root = storePathRoot(path, self.realization.store_dir);
+    if (root.len != path.len and self.realization.hasRecipe(root)) {
+        try self.realization.ensureClosure(root);
+        return path;
+    }
+
     const context = (try demandContext(self, value)) orelse return path;
     defer context.deinit(self.allocator);
     if (std.mem.eql(u8, path, context.drv_path)) {
@@ -113,6 +121,14 @@ pub fn demandPathArg(self: *VM, arg: Value) ![]const u8 {
 fn isStorePath(path: []const u8, store_dir: []const u8) bool {
     return std.mem.startsWith(u8, path, store_dir) and
         path.len > store_dir.len and path[store_dir.len] == '/';
+}
+
+/// `<store>/<name>` prefix of a path inside the store (the whole path when
+/// it IS a root). Caller guarantees `isStorePath`.
+fn storePathRoot(path: []const u8, store_dir: []const u8) []const u8 {
+    const rest = path[store_dir.len + 1 ..];
+    const slash = std.mem.indexOfScalar(u8, rest, '/') orelse return path;
+    return path[0 .. store_dir.len + 1 + slash];
 }
 
 fn demandContext(self: *VM, value: Value) !?DemandContext {

--- a/test/e2e/daemon.sh
+++ b/test/e2e/daemon.sh
@@ -99,6 +99,22 @@ else
 fi
 t "daemon: read fresh text object" "text-via-daemon" "$out"
 
+# The subpath analogue: reading `src + "/inner.txt"` out of a fresh ingested
+# tree materializes the tree's store root.
+subread_dir=$(e2e_mktemp)
+mkdir -p "$subread_dir/tree"
+printf 'sub-read-through-root' >"$subread_dir/tree/inner.txt"
+out=$("$FIX" eval --raw --read-write-mode -E "
+  let src = builtins.path { path = $subread_dir/tree; name = \"fix-daemon-e2e-subread\"; };
+  in builtins.readFile (src + \"/inner.txt\")" 2>&1)
+t "daemon: readFile of a fresh tree subpath materializes the root" "sub-read-through-root" "$out"
+mkdir -p "$subread_dir/tree2/sub"
+printf 'nested-leaf' >"$subread_dir/tree2/sub/leaf.txt"
+out=$("$FIX" eval --json --read-write-mode -E "
+  let src = builtins.path { path = $subread_dir/tree2; name = \"fix-daemon-e2e-subread\"; };
+  in builtins.attrNames (builtins.readDir (src + \"/sub\"))" 2>&1)
+t "daemon: readDir of a fresh tree subpath materializes the root" "leaf.txt" "$out"
+
 # An absolute store URI is a Nix/Lix chroot store root. It must not silently
 # delegate to an installed implementation while the native backend is pending.
 local_root=$(e2e_mktemp)


### PR DESCRIPTION
### Problem
Under `--read-write-mode`, `readFile`/`readDir`/`import` on a subpath of a freshly fetched tree (`src + "/version.txt"` where `src` is a `builtins.path`/`fetchGit` result) fails with `No such file or directory`. Pending fetches and recipes are keyed by the tree's store root; `demandPathArg` only probes the exact path.

### Fix
When a missing store path is a subpath, materialize its root's recipe closure; the read then proceeds (or reports its own ENOENT when the file isn't in the tree). Deferred hashed fetches are untouched: `materializePendingFetch` already handles the full demanded path.

### Repro
```console
$ fix eval --read-write-mode --raw -E '
    let src = builtins.path { path = ./tree; name = "t"; };
    in builtins.readFile (src + "/inner.txt")'
error: No such file or directory
```

### Testing
- Two checks added to `test/e2e/daemon.sh` beside the existing root-case check ("realize toFile before readFile"): `readFile` and `readDir` of fresh-tree subpaths. Both fail on the parent commit, pass with this change.
- Full e2e and unit suites otherwise unchanged.