### PR TITLE
fix(flakes): use store-path path inputs verbatim, as Nix does

### DIFF
--- a/src/expr/vm/builtins/flakes.zig
+++ b/src/expr/vm/builtins/flakes.zig
@@ -69,10 +69,26 @@ pub fn builtinFetchTreeEntry(self: *VM, arg: Value) !Value {
     return builtinFetchTree(self, arg);
 }
 
+/// A path that is already a valid store-path root is used verbatim, as
+/// Nix's path fetcher does.
+fn adoptStorePath(self: *VM, path: []const u8, locked_nar_hash: ?[]const u8, last_modified: i64) !?Value {
+    const store_dir = self.realization.store_dir;
+    if (!std.mem.startsWith(u8, path, store_dir)) return null;
+    if (path.len <= store_dir.len + 1 or path[store_dir.len] != '/') return null;
+    const rest = path[store_dir.len + 1 ..];
+    if (rest.len == 0 or std.mem.indexOfScalar(u8, rest, '/') != null) return null;
+    if (self.realization.storeWritesEnabled()) {
+        // A store-shaped name the daemon doesn't know is just a directory.
+        if (!try self.realization.pathIsValid(path)) return null;
+    }
+    return try pathTreeValue(self, path, locked_nar_hash orelse "", last_modified);
+}
+
 pub fn builtinFetchTree(self: *VM, arg: Value) !Value {
     const attrs = try vm_force.forceValue(self, arg);
     if (attrs.isPath()) {
         const path = self.intern.get(attrs.asInternId());
+        if (try adoptStorePath(self, path, null, fetch.sourceLastModified(self, path))) |adopted| return adopted;
         const out = try ingestFetchedTree(self, path, path_ops.baseName(path), "", null);
         defer out.deinit(self.allocator);
         return pathTreeValue(self, out.out_path, out.nar_hash, fetch.sourceLastModified(self, path));
@@ -96,11 +112,14 @@ pub fn builtinFetchTree(self: *VM, arg: Value) !Value {
     if (std.mem.eql(u8, type_value, "path")) {
         const path = try dupPathAttr(self, attrs_id, "path");
         defer self.allocator.free(path);
-        const out = try ingestFetchedTree(self, path, path_ops.baseName(path), "", null);
-        defer out.deinit(self.allocator);
         // A locked pin wins (deterministic across hosts); a bare local path
         // reports the tree's own mtime, as Nix's path fetcher does.
         const last_modified = (try optionalIntAttr(self, attrs_id, "lastModified")) orelse fetch.sourceLastModified(self, path);
+        const locked_hash = try optionalStringAttr(self, attrs_id, "narHash");
+        defer if (locked_hash) |h| self.allocator.free(h);
+        if (try adoptStorePath(self, path, locked_hash, last_modified)) |adopted| return adopted;
+        const out = try ingestFetchedTree(self, path, path_ops.baseName(path), "", null);
+        defer out.deinit(self.allocator);
         return pathTreeValue(self, out.out_path, out.nar_hash, last_modified);
     }
 
@@ -1111,6 +1130,10 @@ fn flakeInputFromStore(self: *VM, attrs: Value) !?Value {
     // The store-path name must match what the fetch would use (see builtinFetchTree).
     const path_attr = if (is_path) (try optionalStringAttr(self, id, "path")) else null;
     defer if (path_attr) |p| self.allocator.free(p);
+    if (path_attr) |p| {
+        const lm = (try optionalIntAttr(self, id, "lastModified")) orelse 0;
+        if (try adoptStorePath(self, p, nar_hash, lm)) |adopted| return adopted;
+    }
     const name_attr = if (!is_path) (try optionalStringAttr(self, id, "name")) else null;
     defer if (name_attr) |n| self.allocator.free(n);
     const name = if (is_path)

--- a/test/e2e/daemon.sh
+++ b/test/e2e/daemon.sh
@@ -99,6 +99,18 @@ else
 fi
 t "daemon: read fresh text object" "text-via-daemon" "$out"
 
+# A `path:` fetch of an existing store path returns it verbatim, as Nix does.
+adopt_dir=$(e2e_mktemp)
+mkdir -p "$adopt_dir/tree"
+printf 'adopt-me' >"$adopt_dir/tree/inner.txt"
+out=$("$FIX" eval --raw --read-write-mode --impure \
+    --extra-experimental-features fetch-tree -E "
+  let a = toString (builtins.path { path = $adopt_dir/tree; name = \"fix-daemon-e2e-adopt\"; });
+  in builtins.seq (builtins.pathExists a)
+    (if (builtins.fetchTree { type = \"path\"; path = a; }).outPath == a
+     then \"adopted-verbatim\" else \"re-ingested\")" 2>&1)
+t "daemon: fetchTree adopts an existing store path verbatim" "adopted-verbatim" "$out"
+
 # An absolute store URI is a Nix/Lix chroot store root. It must not silently
 # delegate to an installed implementation while the native backend is pending.
 local_root=$(e2e_mktemp)


### PR DESCRIPTION
### Problem
`fetchTree` on a path that is already a valid store-path root re-ingests it, minting a differently-named store path (`<hash>-<oldhash>-source`) and diverging every drvPath that embeds it: a NixOS `nix.registry` pin, `NIX_PATH` entries, a `path:` flake input pointing into the store.

### Fix
Adopt valid store-path roots verbatim, as Nix's path fetcher does. Nested or unknown paths keep the ingest path.

### Repro
```console
$ nix eval --raw --impure --expr '(builtins.fetchTree { type = "path"; path = p; }).outPath'
<p, unchanged>
$ fix eval --read-write-mode --raw -E '(builtins.fetchTree { type = "path"; path = p; }).outPath'
/nix/store/<newhash>-<basename-of-p>
```

### Testing
- New `test/e2e/daemon.sh` check: `fetchTree` of a freshly ingested `builtins.path` result returns the identical store path. Fails before, passes after.
- Other suites unchanged.