### PR TITLE
style: zig fmt src/expr/compiler/let.zig

### DIFF
--- a/src/expr/compiler/let.zig
+++ b/src/expr/compiler/let.zig
@@ -653,4 +653,3 @@ pub fn isEagerEvalShape(expr: *const Node) bool {
         else => true,
     };
 }
-


### PR DESCRIPTION
zig build check-static fails on a trailing blank line at end of file.