### PR TITLE
fix(daemon): read AddIndirectRoot's dummy result

### DIFF
--- a/src/store/daemon/client.zig
+++ b/src/store/daemon/client.zig
@@ -406,7 +406,10 @@ pub const DaemonStore = struct {
     pub fn addIndirectRoot(self: *DaemonStore, link_path: []const u8) !void {
         try self.beginOp(.add_indirect_root);
         try wire.writeString(self.w(), link_path);
-        try self.flushAndDrain(); // no result, just the stderr stream
+        try self.flushAndDrain();
+        // The daemon writes a dummy result (1) after the stderr stream;
+        // read it, as Nix's RemoteStore does.
+        _ = try wire.readInt(self.r());
     }
 
     /// Send per-connection client settings (`set_options`, op 19). Field order

--- a/test/e2e/daemon.sh
+++ b/test/e2e/daemon.sh
@@ -99,6 +99,19 @@ else
 fi
 t "daemon: read fresh text object" "text-via-daemon" "$out"
 
+# AddIndirectRoot's dummy result must be consumed so the connection stays
+# usable for the next operation.
+root_dir=$(e2e_mktemp)
+drv2_expr='builtins.derivation {
+  name = "fix-daemon-e2e-2";
+  system = builtins.currentSystem;
+  builder = "/bin/sh";
+  args = [ "-c" "printf second > \"$out\"" ];
+}'
+out=$("$FIX" instantiate --add-root "$root_dir/root" --indirect -E "$drv_expr" -E "$drv2_expr" 2>&1)
+t "daemon: connection survives an indirect root registration" "fix-daemon-e2e-2.drv" "$out"
+t_absent "daemon: no stray result after indirect root" "unknown stderr message" "$out"
+
 # An absolute store URI is a Nix/Lix chroot store root. It must not silently
 # delegate to an installed implementation while the native backend is pending.
 local_root=$(e2e_mktemp)


### PR DESCRIPTION
### Problem
The daemon writes a dummy result after `AddIndirectRoot`'s stderr stream, and Nix's `RemoteStore` reads it. fix leaves it unread, poisoning the connection: the next operation's stderr drain reads the stray byte as a message tag.

### Repro
```console
$ fix instantiate --add-root r --indirect -E <drvA> -E <drvB>
/nix/store/<...>-drvA.drv
error: evaluation failed: unknown stderr message
```

### Fix
Read the dummy result, as `RemoteStore` does.

### Testing
- New `test/e2e/daemon.sh` check: a two-expression `instantiate` with an indirect root must produce both drv paths. Fails before, passes after, against both CppNix and Lix daemons.
- Other suites unchanged.