### PR TITLE
runtime: bind the legacy __-prefixed builtin globals

### DIFF
--- a/src/expr/compiler/literals.zig
+++ b/src/expr/compiler/literals.zig
@@ -407,8 +407,10 @@ pub fn emitAmbientBuiltin(self: *Compiler, name: []const u8) !bool {
     }
 
     if (builtins.hasConstant(name)) {
+        // `__currentSystem` and friends alias the unprefixed `builtins.<name>`.
+        const attr = if (std.mem.startsWith(u8, name, "__")) name[2..] else name;
         try emit.emitOp(self, .push_builtins);
-        try emit.emitGetAttr(self, try self.intern.intern(name));
+        try emit.emitGetAttr(self, try self.intern.intern(attr));
         return true;
     }
 

--- a/src/runtime/builtins.zig
+++ b/src/runtime/builtins.zig
@@ -221,11 +221,42 @@ test "public builtin names round-trip from the canonical id" {
     try std.testing.expect(publicName(.mapAttrValue) == null);
 }
 
+test "legacy __-prefixed globals mirror Nix's bindings" {
+    try std.testing.expectEqual(BuiltinId.elem, ambientIdForName("__elem").?);
+    try std.testing.expectEqual(BuiltinId.compareVersions, ambientIdForName("__compareVersions").?);
+    try std.testing.expectEqual(BuiltinId.toString, ambientIdForName("toString").?);
+    try std.testing.expect(ambientIdForName("__toString") == null);
+    try std.testing.expect(ambientIdForName("__import") == null);
+    try std.testing.expect(ambientIdForName("__derivation") == null);
+    try std.testing.expect(ambientIdForName("elem") == null);
+    try std.testing.expectEqual(BuiltinId.break_, ambientIdForName("break").?);
+    try std.testing.expect(ambientIdForName("__break") == null);
+    try std.testing.expect(ambientIdForName("__derivationStrict") == null);
+    try std.testing.expect(hasConstant("__currentSystem"));
+    try std.testing.expect(hasConstant("__langVersion"));
+    try std.testing.expect(!hasConstant("__true"));
+    try std.testing.expect(!hasConstant("__null"));
+    try std.testing.expect(!hasConstant("__nope"));
+}
+
+/// Nix binds each builtin into the global scope exactly once: the names
+/// below unprefixed, every other one under a `__` prefix (`__elem`,
+/// `__compareVersions`, ...), the pre-`builtins` spelling.
 pub fn ambientIdForName(name: []const u8) ?BuiltinId {
+    if (std.mem.startsWith(u8, name, "__")) {
+        const id = idForName(name[2..]) orelse return null;
+        return if (unprefixedGlobal(id)) null else id;
+    }
     const id = idForName(name) orelse return null;
+    return if (unprefixedGlobal(id)) id else null;
+}
+
+fn unprefixedGlobal(id: BuiltinId) bool {
     return switch (id) {
         .abort,
         .baseNameOf,
+        .break_,
+        .derivationStrict,
         .derivation,
         .dirOf,
         .fetchGit,
@@ -241,14 +272,22 @@ pub fn ambientIdForName(name: []const u8) ?BuiltinId {
         .scopedImport,
         .throw,
         .toString,
-        => id,
-        else => null,
+        => true,
+        else => false,
     };
 }
 
 pub fn hasConstant(name: []const u8) bool {
+    // `__currentSystem`, `__nixVersion`, ... alongside the existing names;
+    // the keyword-like constants (`true`, `false`, `null`) have no `__` form.
+    const stripped = if (std.mem.startsWith(u8, name, "__")) name[2..] else name;
+    if (stripped.len != name.len) {
+        for ([_][]const u8{ "true", "false", "null" }) |keyword| {
+            if (std.mem.eql(u8, keyword, stripped)) return false;
+        }
+    }
     for (constant_bindings) |candidate| {
-        if (std.mem.eql(u8, candidate, name)) return true;
+        if (std.mem.eql(u8, candidate, stripped)) return true;
     }
     return false;
 }


### PR DESCRIPTION
### Problem
Nix's `addConstant`/`addPrimOp` bind the registered name into the global scope as-is and strip a `__` prefix only for the `builtins` attrset entry (`eval.cc`), so each builtin is global under exactly one spelling: a small set registered unprefixed (`toString`, `import`, `map`, `break`, `derivationStrict`, ...), everything else under `__` (`__elem`, `__compareVersions`, `__currentSystem`, ...). fix bound only the unprefixed set, so the `__` forms were undefined variables. nixpkgs still evaluates one (`assert __trace ...` in `nixos/maintainers/option-usages.nix`).

### Fix
Bind the `__` forms, mirroring the registration boundary exactly: unprefixed-registered globals and the keyword constants (`true`/`false`/`null`) have no `__` form.

### Verification
- Exhaustive: for every name in `builtins.attrNames builtins`, bare and `__`-prefixed resolution now agree with `nix-instantiate`, except two pre-existing deviations this change does not touch (bare `currentSystem`/`currentTime`/`langVersion`/`nixPath`/`nixVersion`/`storeDir` also resolve in fix, asserted by the ambient-builtins integration test; `builtins.convertHash` is not implemented).
- A unit test pins the boundary next to the existing name round-trip test, including the negative cases (`__toString`, `__import`, `__derivationStrict`, `__true`).
- Lix (357) and snix (114) conformance corpora pass; nixpkgs universe chunks re-checked with zero drvPath mismatches.