### PR TITLE
vm: count derivation string-coercion against max-call-depth

### DIFF
--- a/src/expr/eval/tests/derivation.zig
+++ b/src/expr/eval/tests/derivation.zig
@@ -416,6 +416,58 @@ test "evaluate minimal derivation builtins" {
     try std.testing.expectEqualStrings("1", preserved_args);
 }
 
+test "deeply nested derivation argument values evaluate" {
+    var ev = try Engine.init(std.testing.allocator, .{ .worker_count = 0 });
+    defer ev.deinit();
+    var source: std.ArrayListUnmanaged(u8) = .empty;
+    defer source.deinit(std.testing.allocator);
+    try source.appendSlice(std.testing.allocator, "let deep = ");
+    for (0..2000) |_| try source.appendSlice(std.testing.allocator, "[ ");
+    try source.append(std.testing.allocator, '1');
+    for (0..2000) |_| try source.appendSlice(std.testing.allocator, " ]");
+    try source.appendSlice(std.testing.allocator,
+        \\; in (builtins.derivation {
+        \\  name = "d";
+        \\  system = "x86_64-linux";
+        \\  builder = ":";
+        \\  attr = deep;
+        \\}).drvPath
+    );
+    _ = try ev.evaluate(source.items);
+}
+
+test "derivation builtin rejects self-referential argument values" {
+    var list_ev = try Engine.init(std.testing.allocator, .{ .worker_count = 0 });
+    defer list_ev.deinit();
+    try std.testing.expectError(
+        error.CallDepthExceeded,
+        list_ev.evaluate(
+            \\let r = [ r ];
+            \\in (builtins.derivation {
+            \\  name = "d";
+            \\  system = "x86_64-linux";
+            \\  builder = ":";
+            \\  attr = r;
+            \\}).drvPath
+        ),
+    );
+
+    var attrs_ev = try Engine.init(std.testing.allocator, .{ .worker_count = 0 });
+    defer attrs_ev.deinit();
+    try std.testing.expectError(
+        error.CallDepthExceeded,
+        attrs_ev.evaluate(
+            \\let r = { outPath = r; };
+            \\in (builtins.derivation {
+            \\  name = "d";
+            \\  system = "x86_64-linux";
+            \\  builder = ":";
+            \\  attr = r;
+            \\}).drvPath
+        ),
+    );
+}
+
 test "derivation builtin rejects missing required attrs" {
     try std.testing.expectError(
         error.MissingAttribute,

--- a/src/expr/vm/builtins/strings.zig
+++ b/src/expr/vm/builtins/strings.zig
@@ -433,6 +433,19 @@ pub fn coerceAttrsToStringValue(self: *VM, attrs: Value) !Value {
 }
 
 pub fn coerceDerivationStringValue(self: *VM, arg: Value) !Value {
+    return coerceDerivationStringValueDepth(self, arg, 0);
+}
+
+/// Nix counts coercion recursion against the same `max-call-depth` budget
+/// as function calls (`EvalState::coerceToString` takes a `CallDepth`
+/// level), so a self-referential value errs like a runaway call chain and
+/// `--option max-call-depth` governs both.
+fn coerceDerivationStringValueDepth(self: *VM, arg: Value, depth: u32) anyerror!Value {
+    if (depth > self.policy.max_call_depth) return vm_trace.callDepthExceeded(self);
+    // Native backstop, same as forceThunkImpl: the logical budget can
+    // exceed what the running stack holds.
+    if (@frameAddress() < self.executionContextConst().stack_limit)
+        return vm_trace.stackOverflow(self);
     const value = try vm_force.forceValue(self, arg);
     switch (value.kind()) {
         .string, .string_context, .heap_string => return value,
@@ -452,13 +465,17 @@ pub fn coerceDerivationStringValue(self: *VM, arg: Value) !Value {
         },
         .bool_false, .null => return Value.string(try self.intern.intern("")),
         .bool_true => return Value.string(try self.intern.intern("1")),
-        .list => return coerceDerivationListToStringValue(self, value.asObjectId()),
-        .attrs => return coerceDerivationAttrsToStringValue(self, value),
+        .list => return coerceDerivationListToStringValueDepth(self, value.asObjectId(), depth),
+        .attrs => return coerceDerivationAttrsToStringValueDepth(self, value, depth),
         else => return error.TypeError,
     }
 }
 
 pub fn coerceDerivationListToStringValue(self: *VM, list_id: ObjectId) !Value {
+    return coerceDerivationListToStringValueDepth(self, list_id, 0);
+}
+
+fn coerceDerivationListToStringValueDepth(self: *VM, list_id: ObjectId, depth: u32) anyerror!Value {
     // GC: root the (bare-id) list across the recursive force-walk.
     const gc_roots = vm_force.rootsBegin(self);
     defer vm_force.rootsEnd(self, gc_roots);
@@ -487,7 +504,7 @@ pub fn coerceDerivationListToStringValue(self: *VM, list_id: ObjectId) !Value {
         if (!first) try out.append(self.allocator, ' ');
         first = false;
         trailing_empty_list = false;
-        const item_value = try coerceDerivationStringValue(self, forced);
+        const item_value = try coerceDerivationStringValueDepth(self, forced, depth + 1);
         // GC: `item_value` may be a FRESH context string (nested-list/attrs
         // coercion) held only in this Zig local — not the rooted list arg.
         // `appendContextEntry` forces (context merge) and can collect; root
@@ -507,13 +524,17 @@ pub fn coerceDerivationListToStringValue(self: *VM, list_id: ObjectId) !Value {
 }
 
 pub fn coerceDerivationAttrsToStringValue(self: *VM, attrs: Value) !Value {
+    return coerceDerivationAttrsToStringValueDepth(self, attrs, 0);
+}
+
+fn coerceDerivationAttrsToStringValueDepth(self: *VM, attrs: Value, depth: u32) anyerror!Value {
     const gc_roots = vm_force.rootsBegin(self);
     defer vm_force.rootsEnd(self, gc_roots);
     vm_force.rootKeep(self, attrs); // held across getAttrValue + callValue + coerce
     const to_string_id = try self.intern.intern("__toString");
     if (self.heap.getAttrValue(attrs.asObjectId(), to_string_id)) |to_string| {
         const result = try vm_closures.callValue(self, try vm_force.forceValue(self, to_string), attrs);
-        return coerceDerivationStringValue(self, result);
+        return coerceDerivationStringValueDepth(self, result, depth + 1);
     } else |err| switch (err) {
         error.MissingAttribute => {},
         else => return err,
@@ -524,5 +545,5 @@ pub fn coerceDerivationAttrsToStringValue(self: *VM, attrs: Value) !Value {
         error.MissingAttribute => return error.TypeError,
         else => return err,
     };
-    return coerceDerivationStringValue(self, out_path);
+    return coerceDerivationStringValueDepth(self, out_path, depth + 1);
 }


### PR DESCRIPTION
### Problem
A self-referential list or attrset reaching a derivation argument recurses natively through the string coercion until the fiber stack faults: SIGSEGV, where Nix reports `stack overflow; max-call-depth exceeded`.

```console
$ fix eval --read-write-mode -E 'let r = [ r ];
    in (derivation { name = "d"; system = "x86_64-linux"; builder = ":"; attr = r; }).drvPath'
Segmentation fault
```

### Fix
Mirror Nix's mechanism: `EvalState::coerceToString` counts each coercion level against the same `max-call-depth` budget as function calls. The coercion here checks `policy.max_call_depth` (the `max-call-depth` setting, default 10000 as in Nix) once per level and raises the shared error. The `forceThunkImpl` native-stack soft guard backstops the recursion the same way it backstops deep thunk forcing, so an undersized stack degrades to a graceful error rather than a fault.

### Verification
- Boundary parity with `nix-instantiate`: nesting depths 5000 and 9000 evaluate to identical drvPaths on both evaluators, 11000 errors on both, and the cycle errors identically.
- Unit tests cover deep-finite, cyclic-list, and cyclic-`outPath` vectors; the test binary segfaults on the parent commit.
- Full e2e and unit suites otherwise unchanged.