### PR TITLE
vm: coerce + operands without store copies when the left is not a string

### DIFF
--- a/src/expr/eval/tests/paths.zig
+++ b/src/expr/eval/tests/paths.zig
@@ -36,6 +36,26 @@ test "non-interpolated path literals fold inside closed attrset and list literal
     try std_testing.expectEqualStrings("[ /test/sub/file.nix ]", dynamic);
 }
 
+test "a path after a non-string concat operand appends as text" {
+    // Nix coerces `+` operands with copyToStore only when the first operand
+    // is a string; an attrset-coerced left concatenates a trailing path as
+    // its text, without realizing it.
+    var ev = try Engine.init(std_testing.allocator, .{ .worker_count = 0 });
+    defer ev.deinit();
+    const rendered = try renderResolvedForTest(&ev,
+        \\[
+        \\  ({ outPath = "/d"; } + /missing/sub)
+        \\  ({ outPath = /d; } + /missing/sub)
+        \\  ({ outPath = "/d"; } + "/str")
+        \\  ("s" + ({ outPath = "/d"; } + /m1))
+        \\]
+    );
+    defer std_testing.allocator.free(rendered);
+    try std_testing.expectEqualStrings(
+        \\[ "/d/missing/sub" "/d/missing/sub" "/d/str" "s/d/m1" ]
+    , rendered);
+}
+
 test "baseNameOf and dirOf reject non-path non-string arguments" {
     try std_testing.expectError(error.TypeError, renderForTest("builtins.baseNameOf 1"));
     try std_testing.expectError(error.TypeError, renderForTest("builtins.dirOf 1"));

--- a/src/expr/vm/strings.zig
+++ b/src/expr/vm/strings.zig
@@ -283,9 +283,24 @@ pub fn concatPathLike(self: *VM, left: Value, right: Value) !Value {
 pub fn concatStringLike(self: *VM, left: Value, right: Value) !Value {
     const gc_roots = force.rootsBegin(self);
     defer force.rootsEnd(self, gc_roots);
-    const left_like = try coerceLanguageStringValue(self, left);
+    const left_forced = try force.forceValue(self, left);
+    force.rootKeep(self, left_forced);
+    // Nix coerces `+` operands with copyToStore only when the first operand
+    // is a string (ExprConcatStrings); a non-string left (an attrset via
+    // outPath/__toString) concatenates path operands as their text.
+    const copy = switch (left_forced.kind()) {
+        .string, .string_context, .heap_string => true,
+        else => false,
+    };
+    const left_like = if (copy)
+        try coerceLanguageStringValue(self, left_forced)
+    else
+        try textStringLike(self, left_forced);
     force.rootKeep(self, left_like); // held across the `right` coercion + appendStringContext forces
-    const right_like = try coerceLanguageStringValue(self, right);
+    const right_like = if (copy)
+        try coerceLanguageStringValue(self, right)
+    else
+        try textStringLike(self, right);
     force.rootKeep(self, right_like); // held across appendStringContext forces
     var context: std.ArrayListUnmanaged(heap_mod.AttrEntry) = .empty;
     defer context.deinit(self.allocator);
@@ -305,6 +320,13 @@ pub fn concatStringLike(self: *VM, left: Value, right: Value) !Value {
         return Value.contextString(try self.heap.addContextStringEntries(text_id, context.items));
     }
     return makeConcatString(self, &.{ left_bytes, right_bytes }, total);
+}
+
+/// `stringLikeValue` with path results flattened to their text, the
+/// copyToStore=false side of Nix's concat coercion.
+fn textStringLike(self: *VM, value: Value) !Value {
+    const like = try stringLikeValue(self, value);
+    return if (like.kind() == .path) Value.string(like.asInternId()) else like;
 }
 
 /// `str_cat` opcode body: coerce the top `count` stack operands


### PR DESCRIPTION
### Problem
Nix's `ExprConcatStrings` coerces each `+` operand with `copyToStore = (first operand is a string)`, so an attrset-coerced left concatenates a trailing path as its text. fix realized the path (and a path-valued `outPath`) into the store regardless of the left operand, erroring on paths that do not exist.

```console
$ nix-instantiate --eval -E '{ outPath = "/d"; } + /missing/sub'
"/d/missing/sub"
$ fix eval -E '{ outPath = "/d"; } + /missing/sub'
error: No such file or directory
```

### Fix
Select the existing non-copying coercion family (`stringLikeValue`, the one path-first concat already uses) when the forced left operand is not a string kind, flattening path results to their text. `__toString`-before-`outPath` ordering in that family matches `coerceToString`.

### Verification
- Probed against `nix-instantiate` over left kinds {string, path, attrset with string and path `outPath`} x right kinds {existing path, missing path, string, attrset}, chained and interpolated forms included: all agree (one error-message wording difference on a mutually rejected input).
- Unit test pins the four previously-diverging vectors.
- Lix (357) and snix (114) conformance corpora pass; nixpkgs universe chunk of 25,196 attrs has zero drvPath mismatches; a 2,006-job flake evaluation is bit-identical to the parent commit outside the fixed vectors.