### PR TITLE
vm: coerce the path builtin's path argument like Nix's coerceToPath

### DIFF
--- a/src/expr/eval/tests/io_fetch.zig
+++ b/src/expr/eval/tests/io_fetch.zig
@@ -1213,6 +1213,41 @@ test "evaluate import through evaluator file cache" {
     try std.testing.expectEqual(@as(u32, 1), ev.sources.imports.entries.count());
 }
 
+test "path builtin coerces an outPath attrset path argument" {
+    var tmp = std.testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(std.testing.io, "tree", .default_dir);
+    try tmp.dir.writeFile(std.testing.io, .{ .sub_path = "tree/f.txt", .data = "payload" });
+
+    const cwd = try std.process.currentPathAlloc(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+    const tree_path = try std.fs.path.resolve(std.testing.allocator, &.{
+        cwd,
+        ".zig-cache",
+        "tmp",
+        &tmp.sub_path,
+        "tree",
+    });
+    defer std.testing.allocator.free(tree_path);
+
+    const source = try std.fmt.allocPrint(std.testing.allocator,
+        \\let
+        \\  direct = builtins.path {{ path = "{s}"; name = "t"; }};
+        \\  viaOutPath = builtins.path {{ path = {{ outPath = "{s}"; }}; name = "t"; }};
+        \\  viaToString = builtins.path {{ path = {{ __toString = _: "{s}"; }}; name = "t"; }};
+        \\  viaDotDot = builtins.path {{ path = {{ outPath = "{s}/x/../."; }}; name = "t"; }};
+        \\in direct == viaOutPath && direct == viaToString && direct == viaDotDot
+    , .{ tree_path, tree_path, tree_path, tree_path });
+    defer std.testing.allocator.free(source);
+
+    var ev = try Engine.init(std.testing.allocator, .{ .worker_count = 0 });
+    defer ev.deinit();
+    ev.setFileIo(std.testing.io);
+
+    const result = try ev.evaluate(source);
+    try std.testing.expect(result.asBool());
+}
+
 test "evaluate path builtins coerce outPath attrsets" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/expr/vm/builtins/paths.zig
+++ b/src/expr/vm/builtins/paths.zig
@@ -125,11 +125,11 @@ pub fn builtinPath(self: *VM, arg: Value) !Value {
     const attrs_id = attrs.asObjectId();
 
     const path_id = try self.intern.intern("path");
-    const path_value = try vm_force.forceValue(self, try self.heap.getAttrValue(attrs_id, path_id));
-    const path = switch (path_value.kind()) {
-        .path, .string, .string_context, .heap_string => try vm_strings.stringBytes(self, path_value),
-        else => return error.TypeError,
-    };
+    // Nix's coerceToPath: paths and strings directly, anything else (an
+    // attrset via outPath/__toString, e.g. a flake input) through the
+    // non-copying string coercion.
+    const path_like = try vm_strings.stringLikeValue(self, try self.heap.getAttrValue(attrs_id, path_id));
+    const path = try vm_strings.stringBytes(self, path_like);
     if (!std.fs.path.isAbsolute(path)) return error.RelativePath;
 
     const name_value = try optionalAttr(self, attrs_id, "name");


### PR DESCRIPTION
### Problem
`builtins.path` rejects an attrset `path` argument with a type error. Nix's `prim_path` routes it through `coerceToPath`: paths and strings directly, `__toString` recursively, anything else through the non-copying string coercion (an attrset via `outPath`), then requires an absolute result. Passing a flake input or derivation-like value as `path` is a common idiom.

```console
$ nix-instantiate --eval --impure -E 'builtins.path { path = { outPath = ./tree; }; name = "t"; }'
"/nix/store/<hash>-t"
$ fix eval --impure -E 'builtins.path { path = { outPath = ./tree; }; name = "t"; }'
error: type error
```

### Fix
Route the `path` attribute through the existing non-copying string coercion (`stringLikeValue`, whose `__toString`-before-`outPath` ordering matches `coerceToPath`). The absolute-path requirement and the other attributes are unchanged.

### Verification
- `outPath`-as-path, `outPath`-as-string, `__toString`, and a non-canonical `/x/../.` argument all produce the store path Nix produces, byte-identical.
- A unit test pins the four vectors against the plain-string argument.
- Lix (357) and snix (114) conformance corpora pass; a nixpkgs universe chunk of 9,732 attrs has zero drvPath mismatches.