### PR TITLE
vm: copy a coerced store-path value under its full basename

### DIFF
--- a/src/expr/vm/builtins/strings.zig
+++ b/src/expr/vm/builtins/strings.zig
@@ -149,7 +149,7 @@ pub fn sourcePathStringValue(self: *VM, path_id: InternId) !Value {
     const path = self.intern.get(path_id);
     if (!std.fs.path.isAbsolute(path)) return string_context.contextStringWithPath(self, path_id);
     if (!try self.files.pathExists(path)) return error.FileNotFound;
-    const store_path = try source_paths.storePathForSource(self.allocator, self.realization, self.files, path);
+    const store_path = try source_paths.storePathForSourceValue(self.allocator, self.realization, self.files, path);
     defer self.allocator.free(store_path);
     return string_context.contextStringWithPath(self, try self.intern.intern(store_path));
 }

--- a/src/expr/vm/strings.zig
+++ b/src/expr/vm/strings.zig
@@ -478,7 +478,7 @@ pub fn sourcePathStringValue(self: *VM, path_id: InternId) !Value {
         return Value.contextString(try self.heap.addContextStringEntries(path_id, &entries));
     }
     if (!try self.files.pathExists(path)) return error.FileNotFound;
-    const store_path = try source_paths.storePathForSource(self.allocator, self.realization, self.files, path);
+    const store_path = try source_paths.storePathForSourceValue(self.allocator, self.realization, self.files, path);
     defer self.allocator.free(store_path);
     const store_path_id = try self.intern.intern(store_path);
     const entries = [_]heap_mod.AttrEntry{

--- a/src/store/realization/source_path.zig
+++ b/src/store/realization/source_path.zig
@@ -24,6 +24,21 @@ pub fn storePathForSource(
     return storePathForSourceName(allocator, realization, files, path, path_ops.baseName(path));
 }
 
+/// `storePathForSource` for a coerced path VALUE: Nix's copyPathToStore
+/// fetches every source unconditionally under its full basename, store
+/// paths included, so /nix/store/<h>-src becomes /nix/store/<h2>-<h>-src.
+/// Store-path STRINGS (an already-coerced source in a derivation context)
+/// keep the passthrough above.
+pub fn storePathForSourceValue(
+    allocator: std.mem.Allocator,
+    realization: *RealizationStore,
+    files: *FileCache,
+    path: []const u8,
+) ![]u8 {
+    if (!std.fs.path.isAbsolute(path)) return allocator.dupe(u8, path);
+    return storePathForSourceName(allocator, realization, files, path, path_ops.baseName(path));
+}
+
 pub fn storePathForSourceName(
     allocator: std.mem.Allocator,
     realization: *RealizationStore,

--- a/test/e2e/daemon.sh
+++ b/test/e2e/daemon.sh
@@ -99,6 +99,25 @@ else
 fi
 t "daemon: read fresh text object" "text-via-daemon" "$out"
 
+# A PATH VALUE at a store path copies under its full basename on string
+# coercion, as Nix's copyPathToStore does; only string-shaped store paths
+# pass through.
+srccopy_dir=$(e2e_mktemp)
+mkdir -p "$srccopy_dir/tree"
+printf 'copy-me' >"$srccopy_dir/tree/inner.txt"
+out=$("$FIX" eval --raw --read-write-mode --impure -E "
+  let sp = builtins.unsafeDiscardStringContext (toString (builtins.path { path = $srccopy_dir/tree; name = \"fix-daemon-e2e-srccopy\"; }));
+      copied = \"\" + (/. + sp);
+      bn = baseNameOf sp;
+      bc = baseNameOf copied;
+      lb = builtins.stringLength bn;
+      lc = builtins.stringLength bc;
+  in builtins.seq (builtins.pathExists sp)
+     (if copied == sp then \"passed-through\"
+      else if lc > lb && builtins.substring (lc - lb) lb bc == bn then \"copied-under-full-basename\"
+      else \"copied-other-name\")" 2>&1)
+t "daemon: a store-path path value copies under its full basename" "copied-under-full-basename" "$out"
+
 # An absolute store URI is a Nix/Lix chroot store root. It must not silently
 # delegate to an installed implementation while the native backend is pending.
 local_root=$(e2e_mktemp)


### PR DESCRIPTION
### Problem
A path value at a store path passes through string coercion unchanged. Nix's `copyPathToStore` fetches every coerced path value unconditionally under its full basename (`path.baseName()`), so `/nix/store/<h>-src` coerces to a fresh `/nix/store/<h2>-<h>-src`. The passthrough produces a self-consistent but Nix-incompatible drvPath for every derivation whose `src` is a store path, which happens whenever a flake input's own code uses `src = ../../.` (its tree is a store path by then).

```console
$ nix-instantiate --eval --impure -E '(builtins.derivation { ...; src = /nix/store/<h>-src; }).drvPath'
"/nix/store/7z6v005j...-d.drv"
$ fix eval --impure --read-write-mode -E '<same>'
"/nix/store/mdr43v01...-d.drv"
```

### Fix
Only the two path-value coercion sites change (a `storePathForSourceValue` variant without the store-path passthrough). Store-path strings, an already-coerced source flowing through derivation contexts, keep the passthrough — matching Nix, where `copyPathToStore` applies to path values and strings carry their store paths as-is. (Complementary to #3: a `fetchTree` `path:` input adopts a store path; a coerced path value copies it.)

### Verification
- The coerced source path and the drvPath of a derivation with a store-path `src` are now identical to `nix-instantiate`, including the copied name shape.
- A `test/e2e/daemon.sh` check pins the copy-and-full-basename behavior; it reports `passed-through` on the parent commit.
- Full e2e otherwise unchanged; a nixpkgs universe chunk of 3,478 attrs has zero drvPath mismatches.