### PR TITLE
fetchers: support the git shallow attribute as Nix does

### DIFF
--- a/src/expr/eval/tests/io_fetch.zig
+++ b/src/expr/eval/tests/io_fetch.zig
@@ -286,6 +286,35 @@ test "evaluate fetchGit builtin for local repository" {
     try std.testing.expect(!includes_untracked.asBool());
 }
 
+test "fetchGit and fetchTree follow Nix's shallow defaults for revCount" {
+    const cwd = try std.process.currentPathAlloc(std.testing.io, std.testing.allocator);
+    defer std.testing.allocator.free(cwd);
+
+    var ev = try Engine.init(std.testing.allocator, .{ .worker_count = 0 });
+    defer ev.deinit();
+    ev.setFileIo(std.testing.io);
+    ev.policy.fetch_tree_enabled = true;
+
+    const cases = [_]struct { args: []const u8, has_rev_count: bool }{
+        .{ .args = "builtins.fetchGit {{ url = \"{s}\"; }}", .has_rev_count = true },
+        .{ .args = "builtins.fetchGit {{ url = \"{s}\"; shallow = true; }}", .has_rev_count = true },
+        .{ .args = "builtins.fetchTree {{ type = \"git\"; url = \"{s}\"; }}", .has_rev_count = false },
+        .{ .args = "builtins.fetchTree {{ type = \"git\"; url = \"{s}\"; shallow = false; }}", .has_rev_count = true },
+    };
+    inline for (cases) |case| {
+        const source = try std.fmt.allocPrint(std.testing.allocator, "builtins.hasAttr \"revCount\" (" ++ case.args ++ ")", .{cwd});
+        defer std.testing.allocator.free(source);
+        const has = try ev.evaluate(source);
+        try std.testing.expectEqual(case.has_rev_count, has.asBool());
+    }
+
+    // The legacy builtin backfills revCount for a shallow fetch, as 0.
+    const zero_source = try std.fmt.allocPrint(std.testing.allocator, "(builtins.fetchGit {{ url = \"{s}\"; shallow = true; }}).revCount", .{cwd});
+    defer std.testing.allocator.free(zero_source);
+    const zero = try ev.evaluate(zero_source);
+    try std.testing.expectEqual(@as(i64, 0), zero.asInt());
+}
+
 test "evaluate fetchurl builtin through fetch cache" {
     var tmp = std.testing.tmpDir(.{});
     defer tmp.cleanup();

--- a/src/expr/vm/builtins.zig
+++ b/src/expr/vm/builtins.zig
@@ -157,5 +157,6 @@ pub fn applyBuiltin(self: *VM, builtin_id: u16, args: []const Value) !Value {
         .pure_guarded => purity.guardedPureValue(self, args[0]),
         .resolve_flake_node => flakes.resolveFlakeNode(self, args[0], args[1], args[2]),
         .compute_nar_hash => fetch.computeNarHash(self, args[0], args[1]),
+        .shallow_rev_count => fetch.shallowRevCount(self, args[0]),
     };
 }

--- a/src/expr/vm/builtins/fetch.zig
+++ b/src/expr/vm/builtins/fetch.zig
@@ -48,6 +48,7 @@ pub const FetchGitSpec = struct {
     rev: ?[]u8,
     ref: ?[]u8,
     submodules: bool,
+    shallow: bool,
 
     pub fn deinit(self: FetchGitSpec, allocator: std.mem.Allocator) void {
         allocator.free(self.url);
@@ -63,6 +64,7 @@ pub const FetchGitSpec = struct {
             .rev = self.rev,
             .ref = self.ref,
             .submodules = self.submodules,
+            .shallow = self.shallow,
         };
     }
 };
@@ -252,23 +254,41 @@ pub fn builtinFetchGit(self: *VM, arg: Value) !Value {
 
     const result = try offloadFetch(self, .git, spec.borrowed());
     defer result.deinit(self.fetchers.allocator);
-    return gitResultValue(self, spec.name, result);
+    // fetchGit always carries `revCount` (0 for a shallow fetch): Nix's
+    // emitTreeAttrs backfills it for the legacy builtin. Only fetchTree
+    // omits it (see the flakes call site).
+    return gitResultValue(self, spec.name, spec.url, result, false);
 }
 
-pub fn gitResultValue(self: *VM, name: []const u8, result: FetchService.GitResult) !Value {
+pub fn gitResultValue(self: *VM, name: []const u8, url: []const u8, result: FetchService.GitResult, omit_rev_count: bool) !Value {
     const out = try ingestFetchedTree(self, result.out_path, name, result.rev, git_filter);
     defer out.deinit(self.allocator);
+    // rev_count -1 marks a truncated history (the repository is shallow but
+    // `shallow = true` was not passed): the attr exists but forcing it errors,
+    // as in Nix. A shallow fetchTree result omits `revCount` entirely instead.
+    const rev_count_value = if (result.rev_count >= 0)
+        Value.int(result.rev_count)
+    else
+        try shared.makeBuiltinThunk(self, .shallow_rev_count, &.{Value.string(try self.intern.intern(url))});
     const entries = [_]heap_mod.AttrEntry{
         .{ .name = try self.intern.intern("lastModified"), .value = Value.int(result.last_modified) },
         .{ .name = try self.intern.intern("lastModifiedDate"), .value = Value.string(try self.intern.intern(result.last_modified_date)) },
         .{ .name = try self.intern.intern("narHash"), .value = try treeNarHashValue(self, out.out_path, out.nar_hash, ".git") },
         .{ .name = try self.intern.intern("outPath"), .value = try fetchedPathValue(self, out.out_path) },
         .{ .name = try self.intern.intern("rev"), .value = Value.string(try self.intern.intern(result.rev)) },
-        .{ .name = try self.intern.intern("revCount"), .value = Value.int(result.rev_count) },
         .{ .name = try self.intern.intern("shortRev"), .value = Value.string(try self.intern.intern(result.short_rev)) },
         .{ .name = try self.intern.intern("submodules"), .value = Value.boolVal(result.submodules) },
+        .{ .name = try self.intern.intern("revCount"), .value = rev_count_value },
     };
-    return Value.attrs(try self.heap.addAttrs(&entries));
+    return Value.attrs(try self.heap.addAttrs(entries[0 .. entries.len - @intFromBool(omit_rev_count)]));
+}
+
+pub fn shallowRevCount(self: *VM, url_value: Value) !Value {
+    const url = self.intern.get(url_value.asInternId());
+    const message = try std.fmt.allocPrint(self.allocator, "'{s}' is a shallow Git repository, so 'revCount' is not available", .{url});
+    defer self.allocator.free(message);
+    try vm_trace.setErrorMessage(self, message);
+    return error.FetchGitShallowRepository;
 }
 
 /// The `narHash` value for a fetched tree: an eager SRI string when we already
@@ -344,13 +364,14 @@ fn fetchGitSpec(self: *VM, arg: Value) !FetchGitSpec {
             .rev = null,
             .ref = null,
             .submodules = false,
+            .shallow = false,
         };
     }
 
-    return fetchGitSpecFromAttrs(self, value.asObjectId());
+    return fetchGitSpecFromAttrs(self, value.asObjectId(), false);
 }
 
-pub fn fetchGitSpecFromAttrs(self: *VM, attrs_id: ObjectId) !FetchGitSpec {
+pub fn fetchGitSpecFromAttrs(self: *VM, attrs_id: ObjectId, shallow_default: bool) !FetchGitSpec {
     const url = try dupPathAttr(self, attrs_id, "url");
     errdefer self.allocator.free(url);
     const name = try optionalStringAttr(self, attrs_id, "name") orelse try self.allocator.dupe(u8, "source");
@@ -360,6 +381,7 @@ pub fn fetchGitSpecFromAttrs(self: *VM, attrs_id: ObjectId) !FetchGitSpec {
     const ref = try optionalStringAttr(self, attrs_id, "ref");
     errdefer if (ref) |owned| self.allocator.free(owned);
     const submodules = try optionalBoolAttr(self, attrs_id, "submodules") orelse false;
+    const shallow = try optionalBoolAttr(self, attrs_id, "shallow") orelse shallow_default;
 
     return .{
         .url = url,
@@ -367,6 +389,7 @@ pub fn fetchGitSpecFromAttrs(self: *VM, attrs_id: ObjectId) !FetchGitSpec {
         .rev = rev,
         .ref = ref,
         .submodules = submodules,
+        .shallow = shallow,
     };
 }
 

--- a/src/expr/vm/builtins/flakes.zig
+++ b/src/expr/vm/builtins/flakes.zig
@@ -66,10 +66,17 @@ pub fn builtinFetchTreeEntry(self: *VM, arg: Value) !Value {
             forced;
         try purity.enforceFetchLocked(self, purity.attrsHaveLock(self, ref_attrs));
     }
-    return builtinFetchTree(self, arg);
+    return fetchTreeImpl(self, arg, true);
 }
 
 pub fn builtinFetchTree(self: *VM, arg: Value) !Value {
+    return fetchTreeImpl(self, arg, false);
+}
+
+/// `fetch_tree_defaults`: the `fetchTree` builtin defaults git inputs to
+/// `shallow = true` (Nix injects the attr in its fetchTree primop); flake
+/// inputs and `fetchGit` default to full history.
+fn fetchTreeImpl(self: *VM, arg: Value, fetch_tree_defaults: bool) !Value {
     const attrs = try vm_force.forceValue(self, arg);
     if (attrs.isPath()) {
         const path = self.intern.get(attrs.asInternId());
@@ -79,7 +86,7 @@ pub fn builtinFetchTree(self: *VM, arg: Value) !Value {
     }
     if (attrs.isString()) {
         const parsed = try builtinParseFlakeRef(self, attrs);
-        return builtinFetchTree(self, parsed);
+        return fetchTreeImpl(self, parsed, fetch_tree_defaults);
     }
     if (!attrs.isAttrs()) return error.TypeError;
 
@@ -125,11 +132,11 @@ pub fn builtinFetchTree(self: *VM, arg: Value) !Value {
     }
 
     if (std.mem.eql(u8, type_value, "git")) {
-        const spec = try fetchGitSpecFromAttrs(self, attrs_id);
+        const spec = try fetchGitSpecFromAttrs(self, attrs_id, fetch_tree_defaults);
         defer spec.deinit(self.allocator);
         const result = try offloadFetch(self, .git, spec.borrowed());
         defer result.deinit(self.fetchers.allocator);
-        return gitResultValue(self, spec.name, result);
+        return gitResultValue(self, spec.name, spec.url, result, spec.shallow);
     }
 
     if (std.mem.eql(u8, type_value, "github") or std.mem.eql(u8, type_value, "gitlab") or std.mem.eql(u8, type_value, "sourcehut")) {

--- a/src/fetchers/fetch/types.zig
+++ b/src/fetchers/fetch/types.zig
@@ -11,6 +11,7 @@ pub const GitSpec = struct {
     rev: ?[]const u8 = null,
     ref: ?[]const u8 = null,
     submodules: bool = false,
+    shallow: bool = false,
 };
 
 pub const UrlSpec = struct {

--- a/src/fetchers/fetch_cache.zig
+++ b/src/fetchers/fetch_cache.zig
@@ -855,7 +855,7 @@ pub const FetchCache = struct {
         const staging = try self.uniqueStagingPath(snapshots, ".snapshot");
         defer self.allocator.free(staging);
         errdefer std.Io.Dir.cwd().deleteTree(io, staging) catch {};
-        const metadata = try git_transport.snapshotLocal(self.allocator, io, path, staging, spec.rev, spec.submodules);
+        const metadata = try git_transport.snapshotLocal(self.allocator, io, path, staging, spec.rev, spec.submodules, spec.shallow);
         const digest = try nar.hashPathDigest(self.allocator, files, staging);
         const encoded = std.fmt.bytesToHex(digest, .lower);
         const snapshot = try std.fs.path.join(self.allocator, &.{ snapshots, encoded[0..32], "source" });
@@ -907,7 +907,7 @@ pub const FetchCache = struct {
         const materialize_path = staging orelse path;
         var attempt: u32 = 1;
         var result = while (true) : (attempt += 1) {
-            break git_transport.materialize(self.allocator, spec.url, materialize_path, spec.rev, spec.ref, spec.submodules, refresh, .{
+            break git_transport.materialize(self.allocator, spec.url, materialize_path, spec.rev, spec.ref, spec.submodules, spec.shallow, refresh, .{
                 .credentials = if (credential) |value| .{ .username = value.username, .password = value.password } else null,
                 .reporter = git_reporter,
                 .ca_file = self.ssl_cert_file,
@@ -931,7 +931,7 @@ pub const FetchCache = struct {
             try self.publishStagedDir(io, value, path);
             // If another process won the atomic directory commit, report the
             // revision actually present at the shared final path.
-            result = try git_transport.materialize(self.allocator, spec.url, path, spec.rev, spec.ref, spec.submodules, false, .{
+            result = try git_transport.materialize(self.allocator, spec.url, path, spec.rev, spec.ref, spec.submodules, spec.shallow, false, .{
                 .credentials = if (credential) |item| .{ .username = item.username, .password = item.password } else null,
                 .ca_file = self.ssl_cert_file,
                 .proxy_url = self.proxyFor(spec.url),
@@ -1072,6 +1072,9 @@ pub const FetchCache = struct {
         if (spec.ref) |ref| try key.appendSlice(self.allocator, ref);
         try key.append(self.allocator, 0);
         try key.append(self.allocator, @intFromBool(spec.submodules));
+        // A depth-1 clone must not be reused for a full-history fetch (or the
+        // reverse), so shallowness is part of the clone's identity, as in Nix.
+        try key.append(self.allocator, @intFromBool(spec.shallow));
 
         const digest = try nix_hash.hashBytes(self.allocator, "sha256", key.items);
         defer self.allocator.free(digest);

--- a/src/fetchers/git_transport.zig
+++ b/src/fetchers/git_transport.zig
@@ -40,6 +40,7 @@ pub fn snapshotLocal(
     destination: []const u8,
     rev: ?[]const u8,
     submodules: bool,
+    shallow: bool,
 ) !Result {
     try ensureInitialized();
     const path_z = try allocator.dupeZ(u8, repository_path);
@@ -61,7 +62,7 @@ pub fn snapshotLocal(
     } else {
         try copyTrackedWorktree(allocator, io, repo.?, repository_path, destination, submodules);
     }
-    return resultFromCommit(repo.?, commit);
+    return resultFromCommit(repo.?, commit, shallow);
 }
 
 var init_mu: sync.BlockingMutex = .{};
@@ -217,6 +218,7 @@ pub fn materialize(
     rev: ?[]const u8,
     ref_name: ?[]const u8,
     submodules: bool,
+    shallow: bool,
     refresh: bool,
     options: Options,
 ) !Result {
@@ -247,6 +249,7 @@ pub fn materialize(
         var clone_opts: c.git_clone_options = undefined;
         try check(c.git_clone_options_init(&clone_opts, c.GIT_CLONE_OPTIONS_VERSION));
         try configureFetch(&clone_opts.fetch_opts, &context);
+        if (shallow) clone_opts.fetch_opts.depth = 1;
         clone_opts.checkout_opts.checkout_strategy = c.GIT_CHECKOUT_NONE;
         try check(c.git_clone(&repo, url_z.ptr, path_z.ptr, &clone_opts));
     } else if (refresh) {
@@ -256,6 +259,7 @@ pub fn materialize(
         var fetch_opts: c.git_fetch_options = undefined;
         try check(c.git_fetch_options_init(&fetch_opts, c.GIT_FETCH_OPTIONS_VERSION));
         try configureFetch(&fetch_opts, &context);
+        if (shallow) fetch_opts.depth = 1;
         fetch_opts.prune = c.GIT_FETCH_PRUNE;
         try check(c.git_remote_fetch(remote.?, null, &fetch_opts, null));
     }
@@ -276,16 +280,24 @@ pub fn materialize(
     try check(c.git_repository_set_head_detached(repo.?, oid));
     if (submodules) try updateSubmodules(repo.?, &context);
 
-    return resultFromCommit(repo.?, commit);
+    return resultFromCommit(repo.?, commit, shallow);
 }
 
-fn resultFromCommit(repo: *c.git_repository, commit: *c.git_commit) !Result {
+fn resultFromCommit(repo: *c.git_repository, commit: *c.git_commit, shallow: bool) !Result {
     const oid = c.git_commit_id(commit);
     var result: Result = undefined;
     var rev_z: [c.GIT_OID_SHA1_HEXSIZE + 1]u8 = undefined;
     _ = c.git_oid_tostr(&rev_z, rev_z.len, oid);
     @memcpy(&result.rev, rev_z[0..result.rev.len]);
-    result.rev_count = try revisionCount(repo, oid);
+    // No walking a truncated history: a requested shallow fetch counts as 0
+    // (Nix's value for it), and an unrequested-shallow repository reports the
+    // -1 sentinel so `revCount` can fail lazily on use, as in Nix.
+    result.rev_count = if (shallow)
+        0
+    else if (c.git_repository_is_shallow(repo) == 1)
+        -1
+    else
+        try revisionCount(repo, oid);
     result.last_modified = @intCast(c.git_commit_time(commit));
     result.last_modified_date = clock.formatUtc(result.last_modified);
     return result;
@@ -571,13 +583,51 @@ test "libgit2 clone, refresh, checkout, and metadata" {
 
     try createTestCommit(testing.allocator, source, "one");
 
-    const first = try materialize(testing.allocator, url, clone_path, null, null, false, true, .{});
+    const first = try materialize(testing.allocator, url, clone_path, null, null, false, false, true, .{});
     try testing.expectEqual(@as(i64, 1), first.rev_count);
     try testing.expect(first.last_modified > 0);
 
     try tmp.dir.writeFile(testing.io, .{ .sub_path = "source/file", .data = "two" });
     try createTestCommit(testing.allocator, source, "two");
-    const second = try materialize(testing.allocator, url, clone_path, null, null, false, true, .{});
+    const second = try materialize(testing.allocator, url, clone_path, null, null, false, false, true, .{});
     try testing.expect(!std.mem.eql(u8, &first.rev, &second.rev));
     try testing.expectEqual(@as(i64, 2), second.rev_count);
+}
+
+test "shallow snapshots skip revCount; a truncated history reports the sentinel" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(testing.io, "source", .default_dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "source/file", .data = "one" });
+    const source = try tmp.dir.realPathFileAlloc(testing.io, "source", testing.allocator);
+    defer testing.allocator.free(source);
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
+    defer testing.allocator.free(root);
+
+    try createTestCommit(testing.allocator, source, "one");
+
+    const full_dest = try std.fs.path.join(testing.allocator, &.{ root, "full" });
+    defer testing.allocator.free(full_dest);
+    const full = try snapshotLocal(testing.allocator, testing.io, source, full_dest, null, false, false);
+    try testing.expectEqual(@as(i64, 1), full.rev_count);
+
+    const shallow_dest = try std.fs.path.join(testing.allocator, &.{ root, "shallow" });
+    defer testing.allocator.free(shallow_dest);
+    const shallow = try snapshotLocal(testing.allocator, testing.io, source, shallow_dest, null, false, true);
+    try testing.expectEqual(@as(i64, 0), shallow.rev_count);
+    try testing.expectEqualStrings(&full.rev, &shallow.rev);
+
+    // A repository is shallow exactly when `.git/shallow` exists.
+    const shallow_marker = try std.fmt.allocPrint(testing.allocator, "{s}\n", .{full.rev});
+    defer testing.allocator.free(shallow_marker);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "source/.git/shallow", .data = shallow_marker });
+    const truncated_dest = try std.fs.path.join(testing.allocator, &.{ root, "truncated" });
+    defer testing.allocator.free(truncated_dest);
+    const truncated = try snapshotLocal(testing.allocator, testing.io, source, truncated_dest, null, false, false);
+    try testing.expectEqual(@as(i64, -1), truncated.rev_count);
+    const allowed_dest = try std.fs.path.join(testing.allocator, &.{ root, "allowed" });
+    defer testing.allocator.free(allowed_dest);
+    const allowed = try snapshotLocal(testing.allocator, testing.io, source, allowed_dest, null, false, true);
+    try testing.expectEqual(@as(i64, 0), allowed.rev_count);
 }

--- a/src/runtime/builtins.zig
+++ b/src/runtime/builtins.zig
@@ -151,6 +151,11 @@ pub const BuiltinId = enum(u16) {
     /// eval, or raises `RestrictedInPureEval` under pure eval. Seeded as a thunk
     /// so the check happens on the forcing VM's policy. Arg: (constant value).
     pure_guarded = 114,
+    /// Internal: raise the shallow-history error on force. Backs `revCount`
+    /// when the repository's history is truncated but `shallow = true` was not
+    /// passed, so the error surfaces only if `revCount` is used, as in Nix.
+    /// Arg: (repository url). See fetch.zig.
+    shallow_rev_count = 115,
 };
 
 /// Public spelling for an id, or null for an evaluator-internal continuation.
@@ -166,6 +171,7 @@ pub fn publicName(id: BuiltinId) ?[]const u8 {
         .resolve_flake_node,
         .compute_nar_hash,
         .pure_guarded,
+        .shallow_rev_count,
         => null,
         .foldlStrict => "foldl'",
         .break_ => "break",
@@ -317,6 +323,7 @@ pub fn arity(id: BuiltinId) u8 {
         .ceil,
         .baseNameOf,
         .dirOf,
+        .shallow_rev_count,
         => 1,
         .hasAttr,
         .getAttr,


### PR DESCRIPTION
### Problem
`builtins.fetchGit` and `fetchTree` silently ignore the `shallow` attribute, so results diverge from Nix in both directions: `fetchTree { type = "git"; }` carries a `revCount` Nix omits (Nix's fetchTree primop injects `shallow = true` for git), and fetching an already-shallow local repository reports a wrong `revCount` where Nix refuses. Shallow fetching is also simply unsupported, so every pinned fetch downloads full history.

### Change
`shallow` is threaded from the builtins through the fetch cache into the transport, following Nix's semantics at each layer:

- A shallow fetch clones with depth 1, under its own clone-cache key (Nix likewise keys its git cache by url + shallowness), and skips the revwalk.
- `builtins.fetchGit { shallow = true; }` reports `revCount = 0` (Nix's `emitTreeAttrs` backfills it for the legacy builtin); a shallow `fetchTree` result omits `revCount` entirely. The `fetchTree` builtin defaults git inputs to `shallow = true` as Nix's primop does; flake inputs and `fetchGit` keep full history.
- A local repository that is itself shallow, fetched without `shallow = true`, keeps `outPath`/`rev` usable and errors only when `revCount` is forced, with Nix's message — matching Nix's lazy behavior (this matters for depth-1 CI checkouts).

### Verification
- `builtins.attrNames` matches `nix-instantiate` for all four fetchGit/fetchTree × shallow cases; `revCount` values match (full history and the shallow 0); a depth-1 clone's `outPath` is byte-identical to Nix's.
- Clone-shape audit against Nix's git cache: shallow marker, history depth of the pinned rev, and separate shallow/full cache identities all agree.
- The lazy shallow-repository behavior matches attr-for-attr (`outPath` ok, `hasAttr revCount` true, force errors) with the same error message.
- New transport and eval unit tests (the transport test crafts a shallow repository via `.git/shallow`, no network); full unit suites, e2e, language conformance suites, and a 4,721-attr nixpkgs differential chunk pass unchanged.