### PR TITLE
fetchers: fetch only the requested git ref, rev, or allRefs

### DIFF
--- a/src/expr/vm/builtins/fetch.zig
+++ b/src/expr/vm/builtins/fetch.zig
@@ -48,6 +48,7 @@ pub const FetchGitSpec = struct {
     rev: ?[]u8,
     ref: ?[]u8,
     submodules: bool,
+    all_refs: bool,
 
     pub fn deinit(self: FetchGitSpec, allocator: std.mem.Allocator) void {
         allocator.free(self.url);
@@ -63,6 +64,7 @@ pub const FetchGitSpec = struct {
             .rev = self.rev,
             .ref = self.ref,
             .submodules = self.submodules,
+            .all_refs = self.all_refs,
         };
     }
 };
@@ -344,6 +346,7 @@ fn fetchGitSpec(self: *VM, arg: Value) !FetchGitSpec {
             .rev = null,
             .ref = null,
             .submodules = false,
+            .all_refs = false,
         };
     }
 
@@ -360,6 +363,7 @@ pub fn fetchGitSpecFromAttrs(self: *VM, attrs_id: ObjectId) !FetchGitSpec {
     const ref = try optionalStringAttr(self, attrs_id, "ref");
     errdefer if (ref) |owned| self.allocator.free(owned);
     const submodules = try optionalBoolAttr(self, attrs_id, "submodules") orelse false;
+    const all_refs = try optionalBoolAttr(self, attrs_id, "allRefs") orelse false;
 
     return .{
         .url = url,
@@ -367,6 +371,7 @@ pub fn fetchGitSpecFromAttrs(self: *VM, attrs_id: ObjectId) !FetchGitSpec {
         .rev = rev,
         .ref = ref,
         .submodules = submodules,
+        .all_refs = all_refs,
     };
 }
 

--- a/src/fetchers/fetch/types.zig
+++ b/src/fetchers/fetch/types.zig
@@ -11,6 +11,7 @@ pub const GitSpec = struct {
     rev: ?[]const u8 = null,
     ref: ?[]const u8 = null,
     submodules: bool = false,
+    all_refs: bool = false,
 };
 
 pub const UrlSpec = struct {

--- a/src/fetchers/fetch_cache.zig
+++ b/src/fetchers/fetch_cache.zig
@@ -894,9 +894,10 @@ pub const FetchCache = struct {
         const marker = try std.fmt.allocPrint(self.allocator, "{s}.fresh", .{path});
         defer self.allocator.free(marker);
         const exists = try hostPathExists(io, git_dir);
-        // A pinned commit is immutable once present. Mutable refs/HEAD obey the
-        // same tarball-ttl policy as URL and Mercurial sources.
-        var refresh = !exists or (spec.rev == null and !try self.timestampFresh(io, marker));
+        // A pinned commit is immutable once present. allRefs always fetches, as
+        // in Nix. Mutable refs/HEAD obey the same tarball-ttl policy as URL and
+        // Mercurial sources.
+        var refresh = !exists or (spec.rev == null and (spec.all_refs or !try self.timestampFresh(io, marker)));
         const credential = try self.gitCredential(spec.url);
         defer if (credential) |value| value.deinit(self.allocator);
         const git_reporter: ?git_transport.Reporter = if (reporter) |r| .{ .ctx = r.ctx, .report = r.report } else null;
@@ -907,7 +908,7 @@ pub const FetchCache = struct {
         const materialize_path = staging orelse path;
         var attempt: u32 = 1;
         var result = while (true) : (attempt += 1) {
-            break git_transport.materialize(self.allocator, spec.url, materialize_path, spec.rev, spec.ref, spec.submodules, refresh, .{
+            break git_transport.materialize(self.allocator, spec.url, materialize_path, spec.rev, spec.ref, spec.submodules, spec.all_refs, refresh, .{
                 .credentials = if (credential) |value| .{ .username = value.username, .password = value.password } else null,
                 .reporter = git_reporter,
                 .ca_file = self.ssl_cert_file,
@@ -931,7 +932,7 @@ pub const FetchCache = struct {
             try self.publishStagedDir(io, value, path);
             // If another process won the atomic directory commit, report the
             // revision actually present at the shared final path.
-            result = try git_transport.materialize(self.allocator, spec.url, path, spec.rev, spec.ref, spec.submodules, false, .{
+            result = try git_transport.materialize(self.allocator, spec.url, path, spec.rev, spec.ref, spec.submodules, spec.all_refs, false, .{
                 .credentials = if (credential) |item| .{ .username = item.username, .password = item.password } else null,
                 .ca_file = self.ssl_cert_file,
                 .proxy_url = self.proxyFor(spec.url),
@@ -1072,6 +1073,8 @@ pub const FetchCache = struct {
         if (spec.ref) |ref| try key.appendSlice(self.allocator, ref);
         try key.append(self.allocator, 0);
         try key.append(self.allocator, @intFromBool(spec.submodules));
+        // An allRefs clone holds refs a targeted clone lacks; keep them apart.
+        try key.append(self.allocator, @intFromBool(spec.all_refs));
 
         const digest = try nix_hash.hashBytes(self.allocator, "sha256", key.items);
         defer self.allocator.free(digest);

--- a/src/fetchers/git_transport.zig
+++ b/src/fetchers/git_transport.zig
@@ -217,6 +217,7 @@ pub fn materialize(
     rev: ?[]const u8,
     ref_name: ?[]const u8,
     submodules: bool,
+    all_refs: bool,
     refresh: bool,
     options: Options,
 ) !Result {
@@ -242,22 +243,20 @@ pub fn materialize(
         .credential_origin = url_z.ptr,
         .reporter = options.reporter,
     };
+    const refspec = try fetchRefspec(allocator, rev, ref_name, all_refs);
+    defer allocator.free(refspec);
     var repo: ?*c.git_repository = null;
     if (c.git_repository_open(&repo, path_z.ptr) < 0) {
-        var clone_opts: c.git_clone_options = undefined;
-        try check(c.git_clone_options_init(&clone_opts, c.GIT_CLONE_OPTIONS_VERSION));
-        try configureFetch(&clone_opts.fetch_opts, &context);
-        clone_opts.checkout_opts.checkout_strategy = c.GIT_CHECKOUT_NONE;
-        try check(c.git_clone(&repo, url_z.ptr, path_z.ptr, &clone_opts));
+        try check(c.git_repository_init(&repo, path_z.ptr, 0));
+        var remote: ?*c.git_remote = null;
+        try check(c.git_remote_create_with_fetchspec(&remote, repo.?, "origin", url_z.ptr, refspec.ptr));
+        defer c.git_remote_free(remote);
+        try fetchTargeted(allocator, remote.?, refspec, rev, ref_name, all_refs, &context);
     } else if (refresh) {
         var remote: ?*c.git_remote = null;
         try check(c.git_remote_lookup(&remote, repo.?, "origin"));
         defer c.git_remote_free(remote);
-        var fetch_opts: c.git_fetch_options = undefined;
-        try check(c.git_fetch_options_init(&fetch_opts, c.GIT_FETCH_OPTIONS_VERSION));
-        try configureFetch(&fetch_opts, &context);
-        fetch_opts.prune = c.GIT_FETCH_PRUNE;
-        try check(c.git_remote_fetch(remote.?, null, &fetch_opts, null));
+        try fetchTargeted(allocator, remote.?, refspec, rev, ref_name, all_refs, &context);
     }
     defer c.git_repository_free(repo);
 
@@ -429,6 +428,48 @@ fn exportTree(
     }
 }
 
+/// Fetch `refspec`, falling back for a pinned rev to the requested ref (or
+/// HEAD): a rev fetches by OID where the transport negotiates it, as Nix
+/// does, but some transports only accept advertised ref names, and the ref's
+/// history must then contain the rev.
+fn fetchTargeted(
+    allocator: std.mem.Allocator,
+    remote: *c.git_remote,
+    refspec: [:0]const u8,
+    rev: ?[]const u8,
+    ref_name: ?[]const u8,
+    all_refs: bool,
+    context: *CallbackContext,
+) !void {
+    var fetch_opts: c.git_fetch_options = undefined;
+    try check(c.git_fetch_options_init(&fetch_opts, c.GIT_FETCH_OPTIONS_VERSION));
+    try configureFetch(&fetch_opts, context);
+    var refspec_ptrs = [_][*c]u8{@constCast(refspec.ptr)};
+    var refspecs = c.git_strarray{ .strings = &refspec_ptrs, .count = 1 };
+    check(c.git_remote_fetch(remote, &refspecs, &fetch_opts, null)) catch |err| {
+        if (rev == null or all_refs) return err;
+        const fallback = try fetchRefspec(allocator, null, ref_name, false);
+        defer allocator.free(fallback);
+        var fallback_ptrs = [_][*c]u8{@constCast(fallback.ptr)};
+        var fallback_refspecs = c.git_strarray{ .strings = &fallback_ptrs, .count = 1 };
+        try check(c.git_remote_fetch(remote, &fallback_refspecs, &fetch_opts, null));
+    };
+}
+
+/// The single refspec Nix fetches: everything under `allRefs`, the pinned rev
+/// itself, or the one requested ref (a plain name means a branch, as in Nix);
+/// the remote's HEAD when nothing is requested.
+fn fetchRefspec(allocator: std.mem.Allocator, rev: ?[]const u8, ref_name: ?[]const u8, all_refs: bool) ![:0]u8 {
+    if (all_refs) return allocator.dupeZ(u8, "+refs/*:refs/*");
+    if (rev) |value| return std.fmt.allocPrintSentinel(allocator, "+{s}:refs/remotes/origin/pinned", .{value}, 0);
+    if (ref_name) |value| {
+        if (std.mem.startsWith(u8, value, "refs/"))
+            return std.fmt.allocPrintSentinel(allocator, "+{s}:{s}", .{ value, value }, 0);
+        return std.fmt.allocPrintSentinel(allocator, "+refs/heads/{s}:refs/remotes/origin/{s}", .{ value, value }, 0);
+    }
+    return allocator.dupeZ(u8, "+HEAD:refs/remotes/origin/HEAD");
+}
+
 fn resolveObject(allocator: std.mem.Allocator, repo: *c.git_repository, rev: ?[]const u8, ref_name: ?[]const u8) !*c.git_object {
     var candidates: [4]?[]u8 = @splat(null);
     defer for (candidates) |candidate| if (candidate) |value| allocator.free(value);
@@ -571,13 +612,101 @@ test "libgit2 clone, refresh, checkout, and metadata" {
 
     try createTestCommit(testing.allocator, source, "one");
 
-    const first = try materialize(testing.allocator, url, clone_path, null, null, false, true, .{});
+    const first = try materialize(testing.allocator, url, clone_path, null, null, false, false, true, .{});
     try testing.expectEqual(@as(i64, 1), first.rev_count);
     try testing.expect(first.last_modified > 0);
 
     try tmp.dir.writeFile(testing.io, .{ .sub_path = "source/file", .data = "two" });
     try createTestCommit(testing.allocator, source, "two");
-    const second = try materialize(testing.allocator, url, clone_path, null, null, false, true, .{});
+    const second = try materialize(testing.allocator, url, clone_path, null, null, false, false, true, .{});
     try testing.expect(!std.mem.eql(u8, &first.rev, &second.rev));
     try testing.expectEqual(@as(i64, 2), second.rev_count);
+}
+
+test "materialize fetches only the requested object unless allRefs" {
+    const testing = std.testing;
+    var tmp = testing.tmpDir(.{});
+    defer tmp.cleanup();
+    try tmp.dir.createDir(testing.io, "source", .default_dir);
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "source/file", .data = "one" });
+    const source = try tmp.dir.realPathFileAlloc(testing.io, "source", testing.allocator);
+    defer testing.allocator.free(source);
+    const root = try tmp.dir.realPathFileAlloc(testing.io, ".", testing.allocator);
+    defer testing.allocator.free(root);
+    const url = try std.fmt.allocPrint(testing.allocator, "file://{s}", .{source});
+    defer testing.allocator.free(url);
+    const source_z = try testing.allocator.dupeZ(u8, source);
+    defer testing.allocator.free(source_z);
+
+    try createTestCommit(testing.allocator, source, "one");
+    // Grow a second branch so fetch breadth is observable, then return HEAD.
+    var default_ref: [128]u8 = undefined;
+    var default_len: usize = 0;
+    {
+        var repo: ?*c.git_repository = null;
+        try check(c.git_repository_open(&repo, source_z.ptr));
+        defer c.git_repository_free(repo);
+        var head: ?*c.git_reference = null;
+        try check(c.git_repository_head(&head, repo.?));
+        defer c.git_reference_free(head);
+        const name = std.mem.span(c.git_reference_name(head.?));
+        default_len = name.len;
+        @memcpy(default_ref[0..name.len], name);
+        var commit: ?*c.git_object = null;
+        try check(c.git_revparse_single(&commit, repo.?, "HEAD"));
+        defer c.git_object_free(commit);
+        var branch: ?*c.git_reference = null;
+        try check(c.git_branch_create(&branch, repo.?, "feature", @ptrCast(commit.?), 0));
+        c.git_reference_free(branch);
+        try check(c.git_repository_set_head(repo.?, "refs/heads/feature"));
+    }
+    try tmp.dir.writeFile(testing.io, .{ .sub_path = "source/file", .data = "two" });
+    try createTestCommit(testing.allocator, source, "two");
+    var feature_rev: [c.GIT_OID_SHA1_HEXSIZE:0]u8 = undefined;
+    {
+        var repo: ?*c.git_repository = null;
+        try check(c.git_repository_open(&repo, source_z.ptr));
+        defer c.git_repository_free(repo);
+        var tip: ?*c.git_object = null;
+        try check(c.git_revparse_single(&tip, repo.?, "refs/heads/feature"));
+        defer c.git_object_free(tip);
+        _ = c.git_oid_tostr(&feature_rev, feature_rev.len + 1, c.git_object_id(tip.?));
+        const default_z = try testing.allocator.dupeZ(u8, default_ref[0..default_len]);
+        defer testing.allocator.free(default_z);
+        try check(c.git_repository_set_head(repo.?, default_z.ptr));
+    }
+    const hasFeatureTip = struct {
+        fn in(alloc: std.mem.Allocator, clone_path: []const u8, spec: []const u8) !bool {
+            const clone_z = try alloc.dupeZ(u8, clone_path);
+            defer alloc.free(clone_z);
+            const spec_z = try alloc.dupeZ(u8, spec);
+            defer alloc.free(spec_z);
+            var repo: ?*c.git_repository = null;
+            try check(c.git_repository_open(&repo, clone_z.ptr));
+            defer c.git_repository_free(repo);
+            var object: ?*c.git_object = null;
+            if (c.git_revparse_single(&object, repo.?, spec_z.ptr) < 0) return false;
+            c.git_object_free(object);
+            return true;
+        }
+    }.in;
+
+    const head_clone = try std.fs.path.join(testing.allocator, &.{ root, "head" });
+    defer testing.allocator.free(head_clone);
+    const head_only = try materialize(testing.allocator, url, head_clone, null, null, false, false, true, .{});
+    try testing.expectEqual(@as(i64, 1), head_only.rev_count);
+    // The local transport copies the whole object store, so breadth shows in
+    // the ref layout: a HEAD fetch must not track the other branch.
+    try testing.expect(!try hasFeatureTip(testing.allocator, head_clone, "refs/heads/feature"));
+    try testing.expect(!try hasFeatureTip(testing.allocator, head_clone, "refs/remotes/origin/feature"));
+
+    const all_clone = try std.fs.path.join(testing.allocator, &.{ root, "all" });
+    defer testing.allocator.free(all_clone);
+    _ = try materialize(testing.allocator, url, all_clone, null, null, false, true, true, .{});
+    try testing.expect(try hasFeatureTip(testing.allocator, all_clone, "refs/heads/feature"));
+
+    const rev_clone = try std.fs.path.join(testing.allocator, &.{ root, "rev" });
+    defer testing.allocator.free(rev_clone);
+    const pinned = try materialize(testing.allocator, url, rev_clone, &feature_rev, null, false, false, true, .{});
+    try testing.expectEqualStrings(&feature_rev, &pinned.rev);
 }


### PR DESCRIPTION
### Problem
`materialize` clones with the default refspec, so every git fetch downloads every branch of the remote — a fetch of one pinned rev of a many-branch repository transfers the whole repository. Nix fetches a single refspec. The `allRefs` attribute was also silently ignored (harmless only because every fetch already behaved like `allRefs = true`).

### Change
Clone through an origin remote configured to the one refspec Nix fetches — `refs/*:refs/*` under `allRefs = true`, the pinned rev itself, the one requested ref (a plain name meaning a branch, as in Nix), or the remote HEAD — and refresh through the same refspec. A rev fetches by OID where the transport negotiates it, as Nix does; on transports that only accept advertised ref names (libgit2 cannot OID-want over git-protocol v0, where Nix's `git fetch` subprocess can via protocol v2), it falls back to fetching the requested ref, whose history must then contain the rev. `allRefs` is honored and always refetches, as in Nix; the refresh no longer prunes (Nix's fetch does not, and pruning a single targeted refspec has nothing left to mean). Shallowness of the clone cache identity gains an `allRefs` bit so targeted and full clones never mix.

### Verification
- On a two-branch test repository, the clone now holds exactly what Nix's cache holds (9 objects, no trace of the other branch; previously 24 objects and every branch tip), and `outPath` matches `nix-instantiate` for rev-at-tip, rev-behind-tip (exercising the fallback), ref-only, HEAD-default, and `allRefs` fetches.
- A real HTTPS fetch (github.com flake-compat at a pinned rev+ref) produces a byte-identical `outPath` to Nix through the new clone path.
- Refresh of an existing targeted clone picks up new upstream commits; a submodule superproject over `git://` matches Nix's `outPath`; a 12-git-input flake's locked inputs are identical to Nix cold and warm.
- One deliberate edge: a rev living only on an unadvertised ref, requested with a different explicit `ref`, errors (add `allRefs = true`, which matches Nix byte-for-byte) — Nix errors identically against servers without SHA-in-want support; the gap exists only where its git subprocess can negotiate protocol v2 and libgit2 cannot.
- New unit test pins the fetched-ref layout; full unit suites, e2e, and a 4,721-attr nixpkgs differential chunk pass unchanged.