### PR TITLE
flakes: serve locked git inputs from a valid store path

### DIFF
--- a/src/expr/vm/builtins/fetch.zig
+++ b/src/expr/vm/builtins/fetch.zig
@@ -317,6 +317,23 @@ pub fn pathTreeValue(self: *VM, path: []const u8, nar_hash: []const u8, last_mod
     return Value.attrs(try self.heap.addAttrs(&entries));
 }
 
+/// A locked git input whose tree is already valid in the store: the same
+/// attrs `gitResultValue` reports, taken from the lock pins instead of a
+/// fetch.
+pub fn gitTreeValue(self: *VM, path: []const u8, nar_hash: []const u8, rev: []const u8, rev_count: i64, last_modified: i64, submodules: bool) !Value {
+    const entries = [_]heap_mod.AttrEntry{
+        .{ .name = try self.intern.intern("lastModified"), .value = Value.int(last_modified) },
+        .{ .name = try self.intern.intern("lastModifiedDate"), .value = Value.string(try self.intern.intern(&clock.formatUtc(last_modified))) },
+        .{ .name = try self.intern.intern("narHash"), .value = try treeNarHashValue(self, path, nar_hash, ".git") },
+        .{ .name = try self.intern.intern("outPath"), .value = try fetchedPathValue(self, path) },
+        .{ .name = try self.intern.intern("rev"), .value = Value.string(try self.intern.intern(rev)) },
+        .{ .name = try self.intern.intern("revCount"), .value = Value.int(rev_count) },
+        .{ .name = try self.intern.intern("shortRev"), .value = Value.string(try self.intern.intern(rev[0..@min(rev.len, 7)])) },
+        .{ .name = try self.intern.intern("submodules"), .value = Value.boolVal(submodules) },
+    };
+    return Value.attrs(try self.heap.addAttrs(&entries));
+}
+
 /// A local source tree's `lastModified`: the root's mtime in whole seconds, as
 /// Nix's path fetcher reports it (0 when the stat fails).
 pub fn sourceLastModified(self: *VM, path: []const u8) i64 {

--- a/src/expr/vm/builtins/flakes.zig
+++ b/src/expr/vm/builtins/flakes.zig
@@ -36,6 +36,7 @@ const fetchGitSpecFromAttrs = fetch.fetchGitSpecFromAttrs;
 const gitResultValue = fetch.gitResultValue;
 const forgeTreeSpec = fetch.forgeTreeSpec;
 const githubTreeValue = fetch.githubTreeValue;
+const gitTreeValue = fetch.gitTreeValue;
 const fetchMercurialSpecFromAttrs = fetch.fetchMercurialSpecFromAttrs;
 const mercurialResultValue = fetch.mercurialResultValue;
 pub const builtinParseFlakeRef = flake_ref.parse;
@@ -1101,12 +1102,16 @@ fn flakeInputFromStore(self: *VM, attrs: Value) !?Value {
     const ty = (try optionalStringAttr(self, id, "type")) orelse return null;
     defer self.allocator.free(ty);
 
-    // Recursive-NAR (sourcePath) inputs only: forges/tarball/path. git/mercurial
-    // ingest differently and are left to fetch; file is flat, not a tree.
+    // Recursive-NAR (sourcePath) inputs whose narHash is verified against the
+    // lock: forges/tarball/path/git all ingest the fetched tree as a NAR under
+    // `source:sha256:<narHash>` (the VCS metadata directory is dropped before
+    // hashing), so the locked narHash alone names the store path. Mercurial's
+    // narHash is unverified and `file` is flat, not a tree; both fetch.
     const is_forge = std.mem.eql(u8, ty, "github") or std.mem.eql(u8, ty, "gitlab") or std.mem.eql(u8, ty, "sourcehut");
     const is_tarball = std.mem.eql(u8, ty, "tarball");
     const is_path = std.mem.eql(u8, ty, "path");
-    if (!is_forge and !is_tarball and !is_path) return null;
+    const is_git = std.mem.eql(u8, ty, "git");
+    if (!is_forge and !is_tarball and !is_path and !is_git) return null;
 
     // The store-path name must match what the fetch would use (see builtinFetchTree).
     const path_attr = if (is_path) (try optionalStringAttr(self, id, "path")) else null;
@@ -1131,6 +1136,18 @@ fn flakeInputFromStore(self: *VM, attrs: Value) !?Value {
         const rev = try optionalStringAttr(self, id, "rev");
         defer if (rev) |r| self.allocator.free(r);
         return try githubTreeValue(self, store_path, nar_hash, rev, null, last_modified);
+    }
+    if (is_git) {
+        // A git tree also exposes rev-derived attrs, which package definitions
+        // read; the lock pins are exactly what the fetch would have reported.
+        // Anything missing (e.g. a shallow lock has no revCount) falls back to
+        // the fetch.
+        const rev = (try optionalStringAttr(self, id, "rev")) orelse return null;
+        defer self.allocator.free(rev);
+        const rev_count = (try optionalIntAttr(self, id, "revCount")) orelse return null;
+        const locked_modified = (try optionalIntAttr(self, id, "lastModified")) orelse return null;
+        const submodules = (try optionalBoolAttr(self, id, "submodules")) orelse false;
+        return try gitTreeValue(self, store_path, nar_hash, rev, rev_count, locked_modified, submodules);
     }
     return try pathTreeValue(self, store_path, nar_hash, last_modified);
 }


### PR DESCRIPTION
### Problem
The locked-narHash fast path covers forge, tarball, and path inputs, and leaves git inputs to fetch — so a locked git input hits its remote on every cold-cache evaluation even when the pinned tree is already in the store. Nix short-circuits all input types alike (`fetchers.cc`: a final input with a `narHash` resolves its store path without fetching).

### Change
Git inputs join the fast path. They ingest the same way as the covered types — the fetched tree is NAR-ingested under `source:sha256:<narHash>` with the `.git` directory dropped before hashing — so the locked narHash alone names the store path, and git narHashes are already verified against the lock on the fetch path. The rev-derived attrs a fetch would report (`rev`, `revCount`, `lastModified`, `submodules`) are pinned in the lock node; a node missing any of them falls back to fetching. The fast-path type set now equals the narHash-verified type set, which is why mercurial (whose narHash is not lock-verified) stays on the fetch path.

### Verification
- With the input's tree valid in the store and its remote unreachable, a locked git input evaluates fully from the lock — `rev`, `revCount`, and file contents — where the parent commit fails with a fetch error; the store path served is byte-identical to the one Nix computes from the lock (`nix-store --print-fixed-path`).
- A lock node missing `revCount` (the shallow-lock shape) falls back to the fetch: it behaves exactly like the parent commit, offline and online.
- A 12-git-input flake's locked inputs are identical to Nix's store paths cold, with a warm store (exercising this path), and with warm caches; full e2e and a 4,721-attr nixpkgs differential chunk pass unchanged.
- One drive-by note rather than a change: the doc comment on `verifyLockedNarHash` says git is skipped, but the body verifies it — the comment looks stale.