### PR TITLE
profiling: run the cycle probes on aarch64

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,7 +31,7 @@ pub fn build(b: *std.Build) void {
     const debug_checks_opt = b.option(bool, "debug-checks", "Enable VM dispatch invariant assertions (defaults to Debug builds)");
     const vm_trace = b.option(bool, "vm-trace", "Enable VM execution tracing (--vm-trace)") orelse false;
     const thunks_log = b.option(bool, "thunks-log", "Enable per-thunk lifecycle event log (--thunks-log)") orelse false;
-    const prof_main = b.option(bool, "prof-main", "Time main thread's hot serial paths via rdtsc; print via --stats") orelse false;
+    const prof_main = b.option(bool, "prof-main", "Time main thread's hot serial paths with the CPU tick counter; print via --stats") orelse false;
     const prof_path = b.option(bool, "prof-path", "Record the force-call tree (workers=1) and report the critical path + source-attributed profile; print via --stats") orelse false;
     if (tsan and (target.result.cpu.arch != .x86_64 or target.result.os.tag != .linux))
         @panic("-Dtsan currently supports only x86_64-linux");

--- a/docs/build.md
+++ b/docs/build.md
@@ -38,7 +38,7 @@ All are `bool` and off unless noted. These are exactly the flags `build.zig` def
 | diagnostics | `debug-checks` | VM dispatch invariant assertions (**defaults on** in Debug builds) |
 | | `vm-trace` | enable VM execution tracing (surfaced by `--vm-trace`) → [cli.md](cli.md) |
 | | `thunks-log` | per-thunk lifecycle event log (surfaced by `--thunks-log`) → [cli.md](cli.md) |
-| profiling | `prof-main` | rdtsc-time the main thread's hot serial paths; reported via `--stats` → [perf/probes.md](perf/probes.md) |
+| profiling | `prof-main` | time the main thread's hot serial paths with the CPU tick counter; reported via `--stats` → [perf/probes.md](perf/probes.md) |
 | | `prof-path` | record the force-call tree + critical path (workers=1); reported via `--stats` → [perf/probes.md](perf/probes.md) |
 | compilation | `profile` | keep symbols + frame pointers (sets `strip=false`, `omit_frame_pointer=false`) |
 | verification | `tsan` | instrument the evaluator graph with ThreadSanitizer; x86_64 Linux only → [concurrency-testing.md](concurrency-testing.md) |

--- a/docs/perf/probes.md
+++ b/docs/perf/probes.md
@@ -46,7 +46,13 @@ The cycle probes read a CPU counter directly, because a system call is too expen
 
 Each report starts with a `timebase=` line that names the counter and gives its frequency, so the reader knows what one tick is worth. The two units are not comparable, and a number from one machine is not comparable with a number from a different machine.
 
-On aarch64 one tick is 10 ns to 41 ns, against a fraction of a nanosecond for the TSC. A cheap scope therefore measures 0 ticks or 1 tick. The totals and the percentages over millions of calls stay correct, but the `avg_excl` column for the cheapest paths is noise on this architecture. A 25 MHz machine reports `force_value: excl_cy=18252279 calls=52500008 avg_excl=0` on `bench/workloads/torture/math-heavy.nix`: the bucket total is sound, the per-call average is below the quantum. Read the shares, not the per-call averages. The `pmccntr_el0` register gives true cycles, but the Linux kernel traps it in userspace by default, so the probes do not use it.
+On aarch64 one tick is 10 ns to 41 ns, against a fraction of a nanosecond for the TSC. One measurement of a cheap scope is therefore 0 ticks or 1 tick.
+
+A mean over many measurements does not have that limit. The error of one measurement is its phase against the tick edge, and that phase does not correlate with the scope, so the errors cancel as the call count grows. `-Dprof-main` prints `avg_excl` as a fraction for this reason, and adds `avg_ns` when the counter states its rate. A 25 MHz machine reports `force_value: excl_cy=16115384 calls=52500008 avg_excl=0.307 avg_ns=12.3` on `bench/workloads/torture/math-heavy.nix`: 12.3 ns per call, from a counter whose tick is 40 ns.
+
+Distrust `avg_ns` only where the call count is small. A row with two calls carries up to one tick of error in each, so a short scope called twice tells you little. Rows with millions of calls are sound.
+
+The `pmccntr_el0` register gives true CPU cycles at core frequency, roughly 100x finer. The probes do not use it: Linux keeps `kernel.perf_user_access` at 0 by default, so the instruction traps, and even when it is 1 the counter needs a `perf_event_open` and an `mmap` per thread to find its index. It also counts cycles that stop and scale with core frequency, which answers a different question than the fixed-rate wall ticks these probes report.
 
 ## `--stats`
 

--- a/docs/perf/probes.md
+++ b/docs/perf/probes.md
@@ -12,14 +12,14 @@ optimization decisions.
 
 | flag | question it answers | output |
 | --- | --- | --- |
-| `-Dprof-main` | Where does main spend cycles, per coarse evaluator operation (e.g. `merge_attrs`, `force_value`, `do_call`), and **does main ever wait**? | rdtsc exclusive-cycle breakdown + piggyback censuses (below), via `--stats` |
+| `-Dprof-main` | Where does main spend cycles, per coarse evaluator operation (e.g. `merge_attrs`, `force_value`, `do_call`), and **does main ever wait**? | exclusive-tick breakdown + piggyback censuses (below), via `--stats` |
 | `-Dprof-path` | What force-thunk path dominates under the profiler's parallel-floor model? | force-call tree + per-chunk self/span time, via `--stats` |
 | `--timeline` | Per-worker **wall-clock timeline** — structured eval/store spans, fiber-run quanta, GC pauses, counters, metrics, and flows | Perfetto JSON, written via `--timeline[=path]` |
 | `-Dthunks-log` | What value did each thunk resolve to, and **where was it created and targeted** — for cross-run comparison | per-thunk lifecycle event log (create/claim/resolve/reset/errored/blackhole), written via `--thunks-log PATH`; `fix thunks diff` compares logs by the stable `(creator, target)` source-location pair |
 
 ### `-Dprof-main` and its piggyback censuses
 
-`-Dprof-main` is the workhorse. Its core is a per-fiber rdtsc stack profiler that charges each instrumented scope its **exclusive** cycles (inclusive delta minus time already attributed to nested instrumented scopes), so the printed number for a routine is time spent inside it but not inside an instrumented child. Only worker 0 (main) updates counters. A fiber can suspend and resume on worker 0 without another fiber splicing scopes into its stack; if it resumes on a helper, its open worker-0 scopes are invalidated and omitted from the report. Helpers otherwise return at the worker-id gate.
+`-Dprof-main` is the workhorse. Its core is a per-fiber tick-counter stack profiler that charges each instrumented scope its **exclusive** cycles (inclusive delta minus time already attributed to nested instrumented scopes), so the printed number for a routine is time spent inside it but not inside an instrumented child. Only worker 0 (main) updates counters. A fiber can suspend and resume on worker 0 without another fiber splicing scopes into its stack; if it resumes on a helper, its open worker-0 scopes are invalidated and omitted from the report. Helpers otherwise return at the worker-id gate.
 
 On the performance model's 2026-07-11 snapshot, `--workers=32` main parked ~3× and waited ~2× while `force_value` dropped from ~23M (w=1) to ~68K; scheduler machinery was ~7% of wall time (see [model](./model.md)). A set of small counters ride the same flag, written only from worker 0:
 
@@ -34,6 +34,19 @@ On the performance model's 2026-07-11 snapshot, `--workers=32` main parked ~3× 
 `-Dprof-main` tells you which routines burn cycles, but not which *Nix source* the eval spends its time in. `-Dprof-path` runs at `--workers=1`, where forcing is cleanly nested (one fiber, LIFO on the C stack): every `forceThunkImpl` is a span containing the spans of the thunks it forced, keyed by body chunk (approximately a Nix source location). Per span it computes `total` (subtree wall cycles), `self = total − Σ child totals`, and `span = self + max(child span)`. Using `max` (not `sum`) over children models independent siblings as parallel, so the root `span` is an estimate of the force-thunk dependency floor. Comparing it with a same-build multi-worker run also exposes discovery serialization, scheduling overhead, and work outside the profiler's attribution model.
 
 Attribution caveat: spans nest on thunk *forces* only, not on direct closure calls (`do_call`/`do_tail_call` keep running in the same dispatch loop). Work in a directly-called closure that forces no thunk is charged to the *forcing* chunk's self-time. Read the flat profile as "which forcing site drives the most call work", and use `-Dprof-main` for operation-level truth.
+
+### Time source
+
+The cycle probes read a CPU counter directly, because a system call is too expensive at their call rate. `src/base/timebase.zig` owns the read.
+
+| architecture | counter | unit |
+| --- | --- | --- |
+| x86_64 | `rdtsc` | one TSC cycle |
+| aarch64 | `cntvct_el0` | one generic-timer tick, 24 MHz to 100 MHz |
+
+Each report starts with a `timebase=` line that names the counter and gives its frequency, so the reader knows what one tick is worth. The two units are not comparable, and a number from one machine is not comparable with a number from a different machine.
+
+On aarch64 one tick is 10 ns to 41 ns, against a fraction of a nanosecond for the TSC. A cheap scope therefore measures 0 ticks or 1 tick. The totals and the percentages over millions of calls stay correct, but the `avg_excl` column for the cheapest paths is noise on this architecture. A 25 MHz machine reports `force_value: excl_cy=18252279 calls=52500008 avg_excl=0` on `bench/workloads/torture/math-heavy.nix`: the bucket total is sound, the per-call average is below the quantum. Read the shares, not the per-call averages. The `pmccntr_el0` register gives true cycles, but the Linux kernel traps it in userspace by default, so the probes do not use it.
 
 ## `--stats`
 

--- a/src/base/fiber.zig
+++ b/src/base/fiber.zig
@@ -36,6 +36,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const base_options = @import("base_options");
+const timebase = @import("timebase.zig");
 
 const tsan_enabled = base_options.tsan_enabled;
 const TSanHandle = if (tsan_enabled) *anyopaque else void;
@@ -59,7 +60,7 @@ comptime {
     }
 }
 
-/// Fiber cost census (piggybacks on `-Dprof-main`): rdtsc bracketing of
+/// Fiber cost census (piggybacks on `-Dprof-main`): tick bracketing of
 /// the swap-in (dispatcher → fiber body) and swap-out (fiber body →
 /// dispatcher) paths, threadlocal so the accumulation itself is free of
 /// coherence traffic. `Worker.runFiber` seeds `census_pre_swap` at its
@@ -68,7 +69,7 @@ comptime {
 /// (run_mu, timeline branch, spec-ctx refresh, `resume_` setup, the asm
 /// swap) and the swap-out window symmetric machinery on the way back.
 /// Zero-footprint when the build flag is off.
-pub const census_enabled: bool = base_options.fiber_census and builtin.cpu.arch == .x86_64;
+pub const census_enabled: bool = base_options.fiber_census and timebase.supported;
 
 threadlocal var census_pre_swap: u64 = 0;
 threadlocal var census_exit_swap: u64 = 0;
@@ -110,14 +111,7 @@ pub noinline fn censusDrain() CensusSample {
 
 pub inline fn censusNow() u64 {
     if (comptime !census_enabled) return 0;
-    var low: u32 = undefined;
-    var high: u32 = undefined;
-    asm volatile ("rdtsc"
-        : [low] "={eax}" (low),
-          [high] "={edx}" (high),
-        :
-        : .{ .memory = true });
-    return (@as(u64, high) << 32) | @as(u64, low);
+    return timebase.read();
 }
 
 /// Minimal saved state for an inactive fiber. The offsets are load-bearing —
@@ -938,4 +932,11 @@ test "reset is valid from the .ready state (never-resumed fiber)" {
     fiber.resume_();
     try testing.expectEqual(@as(u32, 1), ctx.calls);
     try testing.expectEqual(State.finished, fiber.state);
+}
+
+test "the fiber census follows the build flag on every supported arch" {
+    if (!base_options.fiber_census) return error.SkipZigTest;
+    if (!timebase.supported) return error.SkipZigTest;
+    try testing.expect(census_enabled);
+    try testing.expect(censusNow() != 0);
 }

--- a/src/base/root.zig
+++ b/src/base/root.zig
@@ -27,6 +27,7 @@ pub const terminal_color = @import("terminal_color.zig");
 pub const tui = @import("tui.zig");
 pub const observ = @import("observ.zig");
 pub const sha256 = @import("sha256.zig");
+pub const timebase = @import("timebase.zig");
 
 // Common flat re-exports for the most-used types.
 pub const Deque = deque.Deque;
@@ -56,4 +57,5 @@ test {
     _ = tui;
     _ = observ;
     _ = sha256;
+    _ = timebase;
 }

--- a/src/base/timebase.zig
+++ b/src/base/timebase.zig
@@ -1,0 +1,96 @@
+//! Cheap monotonic tick counter for the cycle probes.
+//!
+//! The cycle probes (`-Dprof-main`, `-Dprof-path`) read the time millions of
+//! times in one evaluation. A system call is too expensive at that rate, so
+//! each architecture reads its counter register directly.
+//!
+//! x86_64 reads the time-stamp counter with `rdtsc`. The counter is invariant
+//! on modern parts. It does not stop in a low-power state, and its ratio to
+//! wall time stays constant in one run.
+//!
+//! aarch64 reads the generic timer with `cntvct_el0`. Userspace can always
+//! read this register. All cores count at the same fixed frequency, which
+//! `cntfrq_el0` gives. That frequency is low, from 24 MHz to 100 MHz, so one
+//! tick is 10 ns to 41 ns. A short scope therefore measures 0 ticks or 1 tick.
+//! Only totals over many calls are meaningful on this architecture.
+//!
+//! The read does not execute an `isb` first. The instruction barrier costs
+//! more time than the precision that it gives back at this tick rate.
+//!
+//! The unit is a raw tick. Ticks from two different architectures are not
+//! comparable. A caller that prints ticks also prints `name()` and `hz()`.
+
+const std = @import("std");
+const builtin = @import("builtin");
+
+/// True when this architecture has a counter that `read()` can use.
+pub const supported: bool = switch (builtin.cpu.arch) {
+    .x86_64, .aarch64 => true,
+    else => false,
+};
+
+/// Read the counter. Returns 0 when the architecture has no counter.
+pub inline fn read() u64 {
+    return switch (builtin.cpu.arch) {
+        .x86_64 => blk: {
+            var low: u32 = undefined;
+            var high: u32 = undefined;
+            asm volatile ("rdtsc"
+                : [low] "={eax}" (low),
+                  [high] "={edx}" (high),
+                :
+                : .{ .memory = true });
+            break :blk (@as(u64, high) << 32) | @as(u64, low);
+        },
+        .aarch64 => asm volatile ("mrs %[ticks], cntvct_el0"
+            : [ticks] "=r" (-> u64),
+            :
+            : .{ .memory = true }),
+        else => 0,
+    };
+}
+
+/// Ticks per second, or 0 when the frequency is not available at low cost.
+pub fn hz() u64 {
+    return switch (builtin.cpu.arch) {
+        // The TSC frequency needs calibration against a second clock. The
+        // probes report ratios, so they do not need it.
+        .x86_64 => 0,
+        .aarch64 => asm volatile ("mrs %[freq], cntfrq_el0"
+            : [freq] "=r" (-> u64),
+        ),
+        else => 0,
+    };
+}
+
+/// The counter's name, for a report header.
+pub fn name() []const u8 {
+    return switch (builtin.cpu.arch) {
+        .x86_64 => "rdtsc",
+        .aarch64 => "cntvct_el0",
+        else => "none",
+    };
+}
+
+test "supported agrees with the target architecture" {
+    const expected = builtin.cpu.arch == .x86_64 or builtin.cpu.arch == .aarch64;
+    try std.testing.expectEqual(expected, supported);
+}
+
+test "the counter runs forward" {
+    if (!supported) return error.SkipZigTest;
+    const first = read();
+    const second = read();
+    try std.testing.expect(first != 0);
+    try std.testing.expect(second >= first);
+}
+
+test "aarch64 knows its counter frequency" {
+    if (builtin.cpu.arch != .aarch64) return error.SkipZigTest;
+    try std.testing.expect(hz() > 0);
+}
+
+test "the counter has a name" {
+    if (!supported) return error.SkipZigTest;
+    try std.testing.expect(!std.mem.eql(u8, name(), "none"));
+}

--- a/src/base/timebase.zig
+++ b/src/base/timebase.zig
@@ -72,6 +72,18 @@ pub fn name() []const u8 {
     };
 }
 
+/// Print one line that identifies the counter, for a report header. The
+/// probes print raw ticks, so a reader needs this line to know what one tick
+/// is worth. `prefix` is the report's own tag, for example "prof".
+pub fn reportLine(prefix: []const u8) void {
+    const freq = hz();
+    if (freq == 0) {
+        std.debug.print("{s}: timebase={s}\n", .{ prefix, name() });
+    } else {
+        std.debug.print("{s}: timebase={s} {d} Hz\n", .{ prefix, name(), freq });
+    }
+}
+
 test "supported agrees with the target architecture" {
     const expected = builtin.cpu.arch == .x86_64 or builtin.cpu.arch == .aarch64;
     try std.testing.expectEqual(expected, supported);

--- a/src/base/timebase.zig
+++ b/src/base/timebase.zig
@@ -72,6 +72,20 @@ pub fn name() []const u8 {
     };
 }
 
+/// Convert a tick count to nanoseconds. Returns null when `hz()` does not
+/// know the rate, which is the x86_64 case.
+///
+/// A tick is coarse on aarch64, so one measurement of a short scope is 0
+/// ticks or 1 tick. An average over many measurements is not coarse: the
+/// error of one measurement is its phase against the tick edge, and that
+/// phase is independent of the scope, so the errors cancel as the count
+/// grows. Give this function a mean, not one sample.
+pub fn toNs(ticks: f64) ?f64 {
+    const freq = hz();
+    if (freq == 0) return null;
+    return ticks * std.time.ns_per_s / @as(f64, @floatFromInt(freq));
+}
+
 /// Print one line that identifies the counter, for a report header. The
 /// probes print raw ticks, so a reader needs this line to know what one tick
 /// is worth. `prefix` is the report's own tag, for example "prof".
@@ -82,6 +96,17 @@ pub fn reportLine(prefix: []const u8) void {
     } else {
         std.debug.print("{s}: timebase={s} {d} Hz\n", .{ prefix, name(), freq });
     }
+}
+
+test "a full second of ticks converts to a full second of nanoseconds" {
+    if (hz() == 0) return error.SkipZigTest;
+    const one_second = toNs(@floatFromInt(hz())).?;
+    try std.testing.expectApproxEqRel(@as(f64, 1_000_000_000.0), one_second, 1e-9);
+}
+
+test "the conversion refuses an unknown frequency" {
+    if (hz() != 0) return error.SkipZigTest;
+    try std.testing.expect(toNs(1.0) == null);
 }
 
 test "supported agrees with the target architecture" {

--- a/src/expr/bytecode/chunk/cache/decoder.zig
+++ b/src/expr/bytecode/chunk/cache/decoder.zig
@@ -191,11 +191,28 @@ fn remapLoadedField(
     return len;
 }
 
-fn remapLoadedCode(
+/// Rewrite one chunk's unit-local ordinals into real ids and repair its
+/// sorted invariants, in a single walk of the code.
+///
+/// These were two passes. Each decoded every instruction and asked
+/// `opcode.layout` for its operand shape, so the load walked the same
+/// bytecode twice to do work that is instruction-local on both sides. The
+/// repair reads and writes only the instruction it is looking at, plus the
+/// side-table range that instruction names, so merging the walks keeps the
+/// same result. Order within an instruction is preserved: fields are remapped
+/// first, because `attr_bind` sorts its pairs by the remapped name id.
+///
+/// The repair can rewrite the opcode byte (`attrs_new_named_srt` becomes
+/// `attrs_new_named`). That is safe here for the same reason it was safe in a
+/// separate pass: the two opcodes share an operand layout, and the cursor has
+/// already read this instruction's shape.
+fn remapAndFixChunk(
     code: []u8,
     chunk_ids_so_far: []const types.ChunkId,
     strtab: []const types.InternId,
     deferred_ids: []const u32,
+    attr_names: []const types.InternId,
+    attr_pos: []AttrPosEntry,
 ) Error!void {
     var cursor: opcode_mod.InstructionCursor = .{ .code = code };
     while (cursor.next() catch return corruptAt(@src())) |insn| {
@@ -205,6 +222,7 @@ fn remapLoadedCode(
             off += try remapLoadedField(code, op, f, off, chunk_ids_so_far, strtab, deferred_ids);
         }
         std.debug.assert(off == insn.end);
+        try fixSortedInvariantsAt(code, insn.ip, op, attr_names, attr_pos);
     }
 }
 
@@ -220,11 +238,19 @@ fn remapLoadedCode(
 ///     (name, pos) pairs, so each referenced range is re-sorted in place.
 ///   - `attr_bind`'s operand embeds (name, slot) pairs consumed by a sorted
 ///     merge walk; the pairs are self-contained and re-sorted in place.
-fn fixSortedInvariants(code: []u8, attr_names: []const types.InternId, attr_pos: []AttrPosEntry) Error!void {
-    var cursor: opcode_mod.InstructionCursor = .{ .code = code };
-    while (cursor.next() catch return corruptAt(@src())) |insn| {
-        const ip = insn.ip;
-        const op = insn.op;
+/// One instruction's share of the sorted-invariant repair. Every case reads
+/// and writes only this instruction's own operand bytes plus the side-table
+/// range that instruction names, so the repair can share a walk with the id
+/// remap. It runs after that instruction's fields are remapped, because
+/// `attr_bind` sorts its pairs by the remapped name id.
+fn fixSortedInvariantsAt(
+    code: []u8,
+    ip: usize,
+    op: OpCode,
+    attr_names: []const types.InternId,
+    attr_pos: []AttrPosEntry,
+) Error!void {
+    {
         switch (op) {
             .attrs_new_named_srt, .attrs_new_named_pos_srt => {
                 const count = encoding.readU16(code, ip + 1);
@@ -457,8 +483,14 @@ const CommitContext = struct {
         try self.deps.deferred.registerBatch(self.deferred_entries, self.deferred_ids);
         for (self.chunks, 0..) |*chunk, i| {
             const code = @constCast(chunk.code);
-            remapLoadedCode(code, chunk_ids[0..i], self.strtab, self.deferred_ids) catch unreachable;
-            fixSortedInvariants(code, chunk.attr_names, @constCast(chunk.attr_pos)) catch unreachable;
+            remapAndFixChunk(
+                code,
+                chunk_ids[0..i],
+                self.strtab,
+                self.deferred_ids,
+                chunk.attr_names,
+                @constCast(chunk.attr_pos),
+            ) catch unreachable;
             chunk.scheduling.trivial = builder_mod.classifyTrivialBody(
                 chunk.code,
                 chunk.constants,

--- a/src/expr/bytecode/chunk/cache/decoder.zig
+++ b/src/expr/bytecode/chunk/cache/decoder.zig
@@ -431,43 +431,6 @@ fn decodeChunk(
     return .{ .name = name_id, .chunk = chunk };
 }
 
-fn preflightRemap(code: []const u8, chunk_ids: []const types.ChunkId, strtab: []const types.InternId) Error!void {
-    var cursor: opcode_mod.InstructionCursor = .{ .code = code };
-    while (cursor.next() catch unreachable) |insn| {
-        var off = insn.ip + 1;
-        for (opcode_mod.layout(insn.op)) |field| {
-            switch (field) {
-                .chunk_id => |w| {
-                    const id = chunk_ids[readW(code, off, w)];
-                    if (w == .b2 and id > 0xFFFF) return error.Unfit;
-                },
-                .intern => |w| {
-                    const id = strtab[readW(code, off, w)];
-                    if (w == .b2 and id > 0xFFFF) return error.Unfit;
-                },
-                .attr_path => |w| if (w == .b2) {
-                    var p = off + 1;
-                    var i: usize = 0;
-                    while (i < code[off]) : (i += 1) {
-                        if (strtab[encoding.readU16(code, p)] > 0xFFFF) return error.Unfit;
-                        p += 2;
-                    }
-                },
-                .bind => |w| if (w == .b2) {
-                    var p = off + 4;
-                    var i: usize = 0;
-                    while (i < encoding.readU16(code, off + 2)) : (i += 1) {
-                        if (strtab[encoding.readU16(code, p)] > 0xFFFF) return error.Unfit;
-                        p += 4;
-                    }
-                },
-                .skip, .deferred_id, .const_idx, .slot, .cap1, .count, .jump, .captures, .captures_slot, .mix => {},
-            }
-            off += opcode_mod.fieldLen(field, code, off);
-        }
-    }
-}
-
 const CommitContext = struct {
     deps: LoadDeps,
     chunks: []Chunk,
@@ -479,7 +442,18 @@ const CommitContext = struct {
         const self: *CommitContext = @ptrCast(@alignCast(raw));
         // All possible width failures precede deferred publication. The full
         // wire validator already proved every ordinal and side-table range.
-        for (self.chunks) |chunk| try preflightRemap(chunk.code, chunk_ids, self.strtab);
+        for (self.chunks, 0..) |chunk, i| try validator.validateAndPreflightCode(
+            chunk.code,
+            @intCast(i),
+            @intCast(self.deferred_entries.len),
+            @intCast(self.strtab.len),
+            @intCast(chunk.constants.len),
+            @intCast(chunk.attr_names.len),
+            @intCast(chunk.attr_pos.len),
+            @intCast(chunk.capture_bytes.len),
+            chunk_ids,
+            self.strtab,
+        );
         try self.deps.deferred.registerBatch(self.deferred_entries, self.deferred_ids);
         for (self.chunks, 0..) |*chunk, i| {
             const code = @constCast(chunk.code);
@@ -613,9 +587,14 @@ pub fn load(bytes: []const u8, deps: LoadDeps) Error!LoadResult {
         .deferred_entries = deferred_entries,
         .deferred_ids = new_deferred_ids,
     };
+    // `prepare` is where the code check now runs, so this has to keep the
+    // cache error set intact instead of flattening a malformed blob into
+    // `Uncacheable`. Anything else is a registry failure.
     deps.registry.registerNamedBatch(chunks, names, new_chunk_ids, &commit, CommitContext.prepare) catch |e| switch (e) {
         error.OutOfMemory => return error.OutOfMemory,
         error.Unfit => return error.Unfit,
+        error.Corrupt => return error.Corrupt,
+        error.Stale => return error.Stale,
         else => return error.Uncacheable,
     };
     loaded_count = 0;

--- a/src/expr/bytecode/chunk/cache/tests.zig
+++ b/src/expr/bytecode/chunk/cache/tests.zig
@@ -643,3 +643,58 @@ test "cache load does not allocate for empty chunk side tables" {
     // allocate for real.
     try testing.expect(counting.allocations <= 3 * result.chunk_count);
 }
+
+test "reverse-ordered attrs and pattern binds survive a cache roundtrip" {
+    const allocator = testing.allocator;
+    // Names declared in descending order drive the sorted-invariant fixups on
+    // load: the attrset ops fall back from their `_srt` form, and the pattern
+    // bind pairs are re-sorted in place. Both run in the same walk as the id
+    // remap, so a fusion mistake shows up here.
+    const source =
+        \\let
+        \\  attrs = { zeta = 1; mid = 2; alpha = 3; };
+        \\  pat = { zulu, yankee ? 4, alfa }: zulu + yankee + alfa;
+        \\  nested = { q = { zz = 1; aa = 2; }; b = 3; };
+        \\in [ attrs.alpha attrs.zeta (pat { zulu = 5; alfa = 6; }) nested.q.aa ]
+    ;
+
+    var ev1 = try Engine.init(allocator, .{ .worker_count = 0 });
+    defer ev1.deinit();
+    const top1 = try ev1.compileSource(source, "sorted-roundtrip.nix");
+    var ids = try collectUnit(allocator, &ev1, top1);
+    defer ids.deinit(allocator);
+
+    const bytes = try serialize(allocator, ev1.chunkRegistry(), &ev1.intern, &ev1.heap, &ev1.compilation.deferred_table, .{
+        .source_path = "sorted-roundtrip.nix",
+        .chunk_ids = ids.items,
+        .deferred_ids = &.{},
+    });
+    defer allocator.free(bytes);
+
+    var ev2 = try Engine.init(allocator, .{ .worker_count = 0 });
+    defer ev2.deinit();
+    var ast_arena = ast.AstArena.init(allocator);
+    defer ast_arena.deinit();
+
+    const result = try load(bytes, .{
+        .allocator = ev2.allocator,
+        .registry = &ev2.registry,
+        .intern = &ev2.intern,
+        .heap = &ev2.heap,
+        .deferred = &ev2.compilation.deferred_table,
+        .ast_arena = &ast_arena,
+        .source = source,
+        .base_path = null,
+        .source_path = "sorted-roundtrip.nix",
+        .policy = .{},
+    });
+    try testing.expectEqual(@as(u32, @intCast(ids.items.len)), result.chunk_count);
+
+    var d1 = try disasmChunk(allocator, &ev1, top1);
+    defer d1.deinit(allocator);
+    var d2 = try disasmChunk(allocator, &ev2, result.top);
+    defer d2.deinit(allocator);
+
+    try testing.expectEqual(d1.lines.len, d2.lines.len);
+    for (d1.lines, d2.lines) |a, b| try testing.expectEqualStrings(a.name, b.name);
+}

--- a/src/expr/bytecode/chunk/cache/tests.zig
+++ b/src/expr/bytecode/chunk/cache/tests.zig
@@ -591,3 +591,55 @@ test "computeKey is stable for identical inputs and varies with codegen policy" 
     const k7 = computeKey("let x = 1; in x", "a.nix", no_named);
     try testing.expect(!std.mem.eql(u8, &k5, &k7));
 }
+
+test "cache load does not allocate for empty chunk side tables" {
+    const allocator = testing.allocator;
+    // Bodies with no captures, no named function arguments and no attr
+    // tables: the side tables that a real unit leaves empty most of the time.
+    const source =
+        \\[ (a: 1) (b: 2) (c: 3) (d: 4) (e: 5) (f: 6) (g: 7) (h: 8) ]
+    ;
+
+    var ev1 = try Engine.init(allocator, .{ .worker_count = 0 });
+    defer ev1.deinit();
+    const top1 = try ev1.compileSource(source, "empty-tables.nix");
+    var ids = try collectUnit(allocator, &ev1, top1);
+    defer ids.deinit(allocator);
+
+    const bytes = try serialize(allocator, ev1.chunkRegistry(), &ev1.intern, &ev1.heap, &ev1.compilation.deferred_table, .{
+        .source_path = "empty-tables.nix",
+        .chunk_ids = ids.items,
+        .deferred_ids = &.{},
+    });
+    defer allocator.free(bytes);
+
+    var ev2 = try Engine.init(allocator, .{ .worker_count = 0 });
+    defer ev2.deinit();
+    var ast_arena = ast.AstArena.init(allocator);
+    defer ast_arena.deinit();
+
+    // Counts what the decoder allocates. The registry keeps its own allocator,
+    // so batch registration stays out of this number.
+    var counting = std.testing.FailingAllocator.init(ev2.allocator, .{});
+    const result = try load(bytes, .{
+        .allocator = counting.allocator(),
+        .registry = &ev2.registry,
+        .intern = &ev2.intern,
+        .heap = &ev2.heap,
+        .deferred = &ev2.compilation.deferred_table,
+        .ast_arena = &ast_arena,
+        .source = source,
+        .base_path = null,
+        .source_path = "empty-tables.nix",
+        .policy = .{},
+    });
+
+    try testing.expect(result.chunk_count >= 8);
+    // `decodeChunk` has eight allocation sites per chunk, but a zero-length
+    // request never reaches the allocator: `Allocator.allocBytesWithAlignment`
+    // returns a dangling aligned pointer for a zero byte count. Only the
+    // non-empty side tables cost a block, which for these bodies is the code
+    // and the source map. Guards against a change that makes every site
+    // allocate for real.
+    try testing.expect(counting.allocations <= 3 * result.chunk_count);
+}

--- a/src/expr/bytecode/chunk/cache/validator.zig
+++ b/src/expr/bytecode/chunk/cache/validator.zig
@@ -75,7 +75,20 @@ fn boundedRange(start: u32, count: u32, limit: usize) Error!void {
     if (@as(usize, end) > limit) return corruptAt(@src());
 }
 
-fn validateNormalizedCode(
+/// Validate one loaded chunk's code and prove every id it will be rewritten
+/// to still fits its operand width. Read-only: the caller runs this over
+/// every chunk of the unit before it mutates any of them.
+///
+/// These were two walks. `validateUnit` checked the wire form of the code,
+/// and the decoder's preflight then re-walked the same instructions to check
+/// widths. Both are per-field and read-only, so they share one pass. Each arm
+/// validates the index before the width check consumes it, which is what lets
+/// `chunk_ids` and `strtab` be indexed here without a second bounds test.
+///
+/// `chunk_ordinal` keeps a chunk from naming a later one: a unit registers
+/// children before parents, so a `.chunk_id` may only point at an earlier
+/// ordinal.
+pub fn validateAndPreflightCode(
     code: []const u8,
     chunk_ordinal: u32,
     deferred_count: u32,
@@ -84,6 +97,8 @@ fn validateNormalizedCode(
     attr_names_count: u32,
     attr_pos_count: u32,
     capture_bytes_len: u32,
+    chunk_ids: []const types.ChunkId,
+    strtab: []const types.InternId,
 ) Error!void {
     var cursor: opcode_mod.InstructionCursor = .{ .code = code };
     while (cursor.next() catch return corruptAt(@src())) |insn| {
@@ -92,15 +107,25 @@ fn validateNormalizedCode(
             const len = opcode_mod.checkedFieldLen(field, code, off) catch return corruptAt(@src());
             switch (field) {
                 .deferred_id => |w| try validateIndex(readW(code, off, w), deferred_count),
-                .chunk_id => |w| try validateIndex(readW(code, off, w), chunk_ordinal),
-                .intern => |w| try validateIndex(readW(code, off, w), str_count),
+                .chunk_id => |w| {
+                    const ordinal = readW(code, off, w);
+                    try validateIndex(ordinal, chunk_ordinal);
+                    if (w == .b2 and chunk_ids[ordinal] > 0xFFFF) return error.Unfit;
+                },
+                .intern => |w| {
+                    const idx = readW(code, off, w);
+                    try validateIndex(idx, str_count);
+                    if (w == .b2 and strtab[idx] > 0xFFFF) return error.Unfit;
+                },
                 .const_idx => try validateIndex(encoding.readU16(code, off), const_count),
                 .attr_path => |w| {
                     const count = code[off];
                     var p = off + 1;
                     var i: usize = 0;
                     while (i < count) : (i += 1) {
-                        try validateIndex(readW(code, p, w), str_count);
+                        const idx = readW(code, p, w);
+                        try validateIndex(idx, str_count);
+                        if (w == .b2 and strtab[idx] > 0xFFFF) return error.Unfit;
                         p += w.bytes();
                     }
                 },
@@ -109,7 +134,9 @@ fn validateNormalizedCode(
                     var p = off + 4;
                     var i: usize = 0;
                     while (i < count) : (i += 1) {
-                        try validateIndex(readW(code, p, w), str_count);
+                        const idx = readW(code, p, w);
+                        try validateIndex(idx, str_count);
+                        if (w == .b2 and strtab[idx] > 0xFFFF) return error.Unfit;
                         p += w.bytes() + 2;
                     }
                 },
@@ -151,9 +178,15 @@ fn validateNormalizedCode(
     }
 }
 
-/// Complete wire preflight. A checksum-valid but malformed
+/// Wire preflight for everything a decode reads: header, checksum, string and
+/// name tables, scopes, deferred entries, and each chunk's records. The code
+/// bytes are checked separately by `validateAndPreflightCode`, which the
+/// decoder runs once per chunk after decode.
+///
+/// Together the two still hold the guarantee: a checksum-valid but malformed
 /// blob reaches no intern table, heap, name tree, deferred table, AST arena,
-/// or chunk registry mutation.
+/// or chunk registry mutation. Decoding a chunk only copies its code; nothing
+/// interprets those bytes until the code check has passed.
 pub fn validateUnit(allocator: std.mem.Allocator, bytes: []const u8, source_len: usize) Error!void {
     var r: Reader = .{ .bytes = bytes };
     if (!std.mem.eql(u8, try r.bytesN(4), "FIXC")) return corruptAt(@src());
@@ -265,7 +298,10 @@ pub fn validateUnit(allocator: std.mem.Allocator, bytes: []const u8, source_len:
             if (start > end or end > code.len) return corruptAt(@src());
             try validateSpanRecord(&r, str_count);
         }
-        try validateNormalizedCode(code, i, deferred_count, str_count, const_count, attr_names_count, attr_pos_count, capture_len);
+        // The code bytes themselves are checked by `validateAndPreflightCode`,
+        // which the decoder runs over every chunk after decode and before it
+        // mutates anything. Everything a decode reads to get here is checked
+        // above, including the source-map bounds against `code.len`.
     }
     if (r.pos != bytes.len) return corruptAt(@src());
 }

--- a/src/expr/eval/workers/scheduler.zig
+++ b/src/expr/eval/workers/scheduler.zig
@@ -26,13 +26,13 @@
 //! (demand-driven) submissions skip the cap.
 
 const std = @import("std");
-const builtin = @import("builtin");
 const types = @import("runtime").types;
 const sync = @import("base").sync;
 const gc = @import("runtime").gc;
 const heap_mod = @import("runtime").heap;
 const containers = @import("base");
 const clock = @import("base").clock;
+const timebase = @import("base").timebase;
 const build_options = @import("build_options");
 pub const Config = @import("scheduler/config.zig").Config;
 const gc_barrier_mod = @import("scheduler/gc_barrier.zig");
@@ -45,11 +45,11 @@ pub const WakeWord = queue.WakeWord;
 
 /// Idle-scan cost census (piggybacks on `-Dprof-main`, like the probes in
 /// `probe/prof.zig` — the scheduler can't import that layer, so the tiny
-/// rdtsc + flush machinery is local). Buckets the cycles each drain-loop
+/// tick + flush machinery is local). Buckets the cycles each drain-loop
 /// probe class burns (own pops vs the O(N) per-peer steal scans over the
 /// ready queues / urgent deques / novel rings / spec rings / cont deques).
 /// Zero-cost when the build flag is off.
-const scan_census_on = build_options.prof_main and builtin.cpu.arch == .x86_64;
+const scan_census_on = build_options.prof_main and timebase.supported;
 
 pub const ScanCensus = struct {
     ready_pop_cy: u64 = 0,
@@ -78,14 +78,7 @@ var scan_totals: ScanCensus = .{};
 
 inline fn rdtscScan() u64 {
     if (comptime !scan_census_on) return 0;
-    var low: u32 = undefined;
-    var high: u32 = undefined;
-    asm volatile ("rdtsc"
-        : [low] "={eax}" (low),
-          [high] "={edx}" (high),
-        :
-        : .{ .memory = true });
-    return (@as(u64, high) << 32) | @as(u64, low);
+    return timebase.read();
 }
 
 inline fn scanEnd(comptime prefix: []const u8, t0: u64, hit: bool) void {
@@ -1592,4 +1585,11 @@ test "parkWorker returns immediately once shutdown is flagged" {
     // No wake pending and shutdown is set — parkWorker must not block
     // waiting for a wake that will never come.
     sched.parkWorker(1);
+}
+
+test "the scan census follows the build flag on every supported arch" {
+    if (!build_options.prof_main) return error.SkipZigTest;
+    if (!timebase.supported) return error.SkipZigTest;
+    try std.testing.expect(scan_census_on);
+    try std.testing.expect(rdtscScan() != 0);
 }

--- a/src/expr/evaluator.zig
+++ b/src/expr/evaluator.zig
@@ -1710,23 +1710,27 @@ pub const Engine = struct {
         defer self.allocator.free(bytes);
 
         var arena = ast_mod.AstArena.init(self.allocator);
-        const result = chunk_cache.load(bytes, .{
-            .allocator = self.allocator,
-            .registry = &self.registry,
-            .intern = &self.intern,
-            .heap = &self.heap,
-            .deferred = &self.compilation.deferred_table,
-            .ast_arena = &arena,
-            .source = source,
-            .base_path = base_path,
-            .source_path = source_path,
-            .policy = self.policy,
-        }) catch |err| {
-            arena.deinit();
-            _ = self.compilation.cache_rejects.fetchAdd(1, .monotonic);
-            if (self.letFloatCensusEnabled())
-                std.debug.print("chunk-cache reject: {s} {s}\n", .{ @errorName(err), source_path orelse "?" });
-            return null;
+        const result = blk: {
+            const clt = prof.start(.chunk_cache_load);
+            defer prof.end(.chunk_cache_load, clt);
+            break :blk chunk_cache.load(bytes, .{
+                .allocator = self.allocator,
+                .registry = &self.registry,
+                .intern = &self.intern,
+                .heap = &self.heap,
+                .deferred = &self.compilation.deferred_table,
+                .ast_arena = &arena,
+                .source = source,
+                .base_path = base_path,
+                .source_path = source_path,
+                .policy = self.policy,
+            }) catch |err| {
+                arena.deinit();
+                _ = self.compilation.cache_rejects.fetchAdd(1, .monotonic);
+                if (self.letFloatCensusEnabled())
+                    std.debug.print("chunk-cache reject: {s} {s}\n", .{ @errorName(err), source_path orelse "?" });
+                return null;
+            };
         };
         // Deferred bodies materialize their synthesized `.elided` nodes from
         // this arena at force time; keep it for the engine's lifetime, same

--- a/src/expr/probe/prof.zig
+++ b/src/expr/probe/prof.zig
@@ -1,6 +1,8 @@
-//! Lightweight rdtsc-based profiler for the main thread's hot
+//! Lightweight tick-counter profiler for the main thread's hot
 //! serial paths. Build-gated on `-Dprof-main`; off-build compiles
-//! to no-ops with zero runtime footprint.
+//! to no-ops with zero runtime footprint. `base.timebase` supplies the
+//! counter, so one tick is a TSC cycle on x86_64 and a generic-timer
+//! tick on aarch64.
 //!
 //! Helpers don't update counters (we only care about main's serial
 //! pathlength). Each evaluator fiber owns its nesting stack, so suspension
@@ -26,9 +28,9 @@
 const std = @import("std");
 const InternTable = @import("runtime").intern.InternTable;
 const ChunkRegistry = @import("../bytecode.zig").chunk.ChunkRegistry;
-const builtin = @import("builtin");
 const build_options = @import("build_options");
 const worker_id = @import("base").worker_id;
+const timebase = @import("base").timebase;
 const BuiltinId = @import("runtime").builtins.BuiltinId;
 const prof_path_mod = @import("prof_path.zig");
 const prof_age = @import("prof_age.zig");
@@ -37,8 +39,8 @@ const prof_fiber = @import("prof_fiber.zig");
 const prof_census = @import("prof_census.zig");
 
 /// Compile-time switch. False when `-Dprof-main` wasn't passed.
-/// `rdtsc` is x86_64-only, so we additionally gate on arch.
-pub const enabled: bool = build_options.prof_main and builtin.cpu.arch == .x86_64;
+/// The probe needs a tick counter, so it also gates on the architecture.
+pub const enabled: bool = build_options.prof_main and timebase.supported;
 
 /// Tag for every instrumented path. Keep names short — they appear
 /// in the stats line as-is.
@@ -258,20 +260,12 @@ inline fn token(stack: *const Stack, idx: usize) u64 {
     return (@as(u64, stack.generation) << 32) | @as(u64, @intCast(idx));
 }
 
-/// Read the TSC. `rdtsc` returns a 64-bit counter formed from
-/// edx:eax. We use it as a coarse time source — the TSC is
-/// invariant on modern x86_64 so it doesn't pause across power
-/// states; the ratio to wall time is constant within a run.
+/// Read the tick counter. The unit is one tick of `base.timebase`: a TSC
+/// cycle on x86_64, a generic-timer tick on aarch64. The name stays `rdtsc`
+/// because `prof_age.zig`, `prof_census.zig` and `vm/force.zig` call it.
 pub inline fn rdtsc() u64 {
     if (!enabled) return 0;
-    var low: u32 = undefined;
-    var high: u32 = undefined;
-    asm volatile ("rdtsc"
-        : [low] "={eax}" (low),
-          [high] "={edx}" (high),
-        :
-        : .{ .memory = true });
-    return (@as(u64, high) << 32) | @as(u64, low);
+    return timebase.read();
 }
 
 /// Start a measurement on the main thread. Returns a sentinel
@@ -472,4 +466,11 @@ test "fiber profiler stacks remain isolated across suspension" {
     end(.force_value, outer);
     try std.testing.expectEqual(@as(usize, 0), suspended.len);
     leaveFiber();
+}
+
+test "the main probe follows the build flag on every supported arch" {
+    if (!build_options.prof_main) return error.SkipZigTest;
+    if (!timebase.supported) return error.SkipZigTest;
+    try std.testing.expect(enabled);
+    try std.testing.expect(rdtsc() != 0);
 }

--- a/src/expr/probe/prof.zig
+++ b/src/expr/probe/prof.zig
@@ -351,6 +351,7 @@ pub inline fn end(comptime path: Path, t: u64) void {
 /// `registry`/`intern` resolve chunk keys to source locations for the
 /// age-at-force per-body breakdown (same shapes as `prof_path.report`).
 pub fn report(registry: *const ChunkRegistry, intern: *const InternTable) void {
+    timebase.reportLine("prof");
     inline for (@typeInfo(Path).@"enum".fields) |f| {
         const samp = samples[f.value];
         if (samp.calls != 0) {

--- a/src/expr/probe/prof.zig
+++ b/src/expr/probe/prof.zig
@@ -92,6 +92,12 @@ pub const Path = enum {
     parse,
     /// `Compiler.compileAndFinish` — AST → bytecode for an imported file.
     compile,
+    /// `chunk_cache.load` — decode a cached unit and register its chunks,
+    /// which replaces `parse` + `compile` on a cache hit. Without this scope
+    /// the work has no bucket of its own, so it lands in the exclusive time of
+    /// whichever builtin drove the import and makes `import` look slow. The
+    /// file read is not included; it happens before this scope opens.
+    chunk_cache_load,
     /// `strictness.stampOnBuilder` — per-chunk strictness analysis (a
     /// second AST walk building NameSets). Sub-phase of `compile`; its
     /// exclusive cycles are carved out of the `compile` bucket.

--- a/src/expr/probe/prof.zig
+++ b/src/expr/probe/prof.zig
@@ -346,6 +346,30 @@ pub inline fn end(comptime path: Path, t: u64) void {
     }
 }
 
+/// Print the mean exclusive ticks per call, then end the line.
+///
+/// The mean is fractional on purpose. Integer division discards everything
+/// below one tick, and one tick is 40 ns on a 25 MHz counter — more than a
+/// cheap scope such as `force_value` costs, which made its average read as
+/// zero. The mean itself keeps the resolution the counter appears to lack,
+/// because each measurement's error is its phase against the tick edge and
+/// those errors cancel over millions of calls.
+///
+/// `avg_ns` appears only when the counter states its rate. See
+/// `base.timebase.toNs`.
+fn printAvgExcl(cycles: u64, calls: u64) void {
+    if (calls == 0) {
+        std.debug.print("\n", .{});
+        return;
+    }
+    const avg = @as(f64, @floatFromInt(cycles)) / @as(f64, @floatFromInt(calls));
+    if (timebase.toNs(avg)) |ns| {
+        std.debug.print(" avg_excl={d:.3} avg_ns={d:.1}\n", .{ avg, ns });
+    } else {
+        std.debug.print(" avg_excl={d:.3}\n", .{avg});
+    }
+}
+
 /// Dump the main-thread path + per-builtin cycle samples
 /// (`--stats`). Lives beside the counters it reads.
 /// `registry`/`intern` resolve chunk keys to source locations for the
@@ -355,13 +379,13 @@ pub fn report(registry: *const ChunkRegistry, intern: *const InternTable) void {
     inline for (@typeInfo(Path).@"enum".fields) |f| {
         const samp = samples[f.value];
         if (samp.calls != 0) {
-            std.debug.print("prof: {s}: excl_cy={d} incl_cy={d} calls={d} avg_excl={d}\n", .{
+            std.debug.print("prof: {s}: excl_cy={d} incl_cy={d} calls={d}", .{
                 f.name,
                 samp.cycles,
                 samp.cycles_inclusive,
                 samp.calls,
-                samp.cycles / samp.calls,
             });
+            printAvgExcl(samp.cycles, samp.calls);
         }
     }
     // String-machinery census.
@@ -389,7 +413,8 @@ pub fn report(registry: *const ChunkRegistry, intern: *const InternTable) void {
     for (top_b) |entry| {
         if (entry.cycles == 0) break;
         const name = @import("runtime").builtins.displayName(@enumFromInt(entry.id));
-        std.debug.print("  {s}: excl={d} incl={d} calls={d} avg_excl={d}\n", .{ name, entry.cycles, entry.incl, entry.calls, entry.cycles / entry.calls });
+        std.debug.print("  {s}: excl={d} incl={d} calls={d}", .{ name, entry.cycles, entry.incl, entry.calls });
+        printAvgExcl(entry.cycles, entry.calls);
     }
     // Attr inline-cache, thunk-memo, repeat-force, and attr-lookup size censuses.
     prof_census.reportCaches();

--- a/src/expr/probe/prof_path.zig
+++ b/src/expr/probe/prof_path.zig
@@ -10,8 +10,8 @@
 //! HOW. Run at `--workers=1`: forcing is then cleanly nested (one
 //! fiber, LIFO on the C stack), so every `forceThunkImpl` claim is a
 //! span that contains exactly the spans of the thunks it forced. We
-//! record each span's wall cycles (rdtsc) and its parent, keyed by the
-//! body chunk (≈ a Nix source location).
+//! record each span's wall ticks (`base.timebase`) and its parent,
+//! keyed by the body chunk (≈ a Nix source location).
 //!
 //! From that tree we compute, per span:
 //!   total = wall cycles of the whole subtree
@@ -41,14 +41,14 @@
 //!   ./zig-out/bin/fix eval --file X --workers=1 --stats 2>&1
 
 const std = @import("std");
-const builtin = @import("builtin");
 const build_options = @import("build_options");
 const BuiltinId = @import("runtime").builtins.BuiltinId;
 const InternTable = @import("runtime").intern.InternTable;
 const ChunkRegistry = @import("../bytecode.zig").chunk.ChunkRegistry;
 const worker_id = @import("base").worker_id;
+const timebase = @import("base").timebase;
 
-pub const enabled: bool = build_options.prof_path and builtin.cpu.arch == .x86_64;
+pub const enabled: bool = build_options.prof_path and timebase.supported;
 
 /// Key space (chunk ids on a NixOS toplevel top out in the low
 /// millions, far under builtin_key_base):
@@ -93,14 +93,7 @@ var root_span: u64 = 0;
 var overflowed: bool = false;
 
 inline fn rdtsc() u64 {
-    var low: u32 = undefined;
-    var high: u32 = undefined;
-    asm volatile ("rdtsc"
-        : [low] "={eax}" (low),
-          [high] "={edx}" (high),
-        :
-        : .{ .memory = true });
-    return (@as(u64, high) << 32) | @as(u64, low);
+    return timebase.read();
 }
 
 /// Begin a force span keyed by `key`. Returns a token for `exit`, or a
@@ -252,4 +245,11 @@ pub fn locName(registry: *const ChunkRegistry, intern: *const InternTable, key: 
     const span = (best orelse return "<no span>").span;
     const file = if (span.file) |fid| intern.get(fid) else "?";
     return std.fmt.bufPrint(&name_scratch, "{s}:{d}:{d}", .{ file, span.line, span.column }) catch "<fmt err>";
+}
+
+test "the path probe follows the build flag on every supported arch" {
+    if (!build_options.prof_path) return error.SkipZigTest;
+    if (!timebase.supported) return error.SkipZigTest;
+    try std.testing.expect(enabled);
+    try std.testing.expect(rdtsc() != 0);
 }

--- a/src/expr/probe/prof_path.zig
+++ b/src/expr/probe/prof_path.zig
@@ -158,6 +158,7 @@ const Agg = struct { self_cy: u64 = 0, total_cy: u64 = 0, calls: u64 = 0 };
 /// Print the critical path and a flat source-attributed profile.
 pub fn report(registry: *const ChunkRegistry, intern: *const InternTable) void {
     if (!enabled) return;
+    timebase.reportLine("prof-path");
     const w = std.debug;
     if (records.items.len == 0) {
         w.print("prof-path: no spans recorded (run with --workers=1)\n", .{});

--- a/src/runtime/thunk.zig
+++ b/src/runtime/thunk.zig
@@ -32,6 +32,7 @@
 const std = @import("std");
 const builtin = @import("builtin");
 const build_options = @import("build_options");
+const timebase = @import("base").timebase;
 const types = @import("types.zig");
 const Value = @import("value.zig").Value;
 const ChunkId = types.ChunkId;
@@ -47,7 +48,7 @@ pub const FailureRef = failure.FailureRef;
 
 /// `-Dprof-main` age-at-force probe support. These fields belong to thunks,
 /// not to the generic synchronization primitive used by imports and I/O.
-pub const created_tsc_enabled: bool = build_options.prof_main and builtin.cpu.arch == .x86_64;
+pub const created_tsc_enabled: bool = build_options.prof_main and timebase.supported;
 const CreatedTsc = if (created_tsc_enabled) u64 else void;
 pub const CreatedDemand = if (created_tsc_enabled) bool else void;
 const SpecDisp = if (created_tsc_enabled) u8 else void;
@@ -62,14 +63,7 @@ inline fn initSpecDisp() SpecDisp {
 
 inline fn nowCreatedTsc() CreatedTsc {
     if (comptime !created_tsc_enabled) return {};
-    var low: u32 = undefined;
-    var high: u32 = undefined;
-    asm volatile ("rdtsc"
-        : [low] "={eax}" (low),
-          [high] "={edx}" (high),
-        :
-        : .{ .memory = true });
-    return (@as(u64, high) << 32) | @as(u64, low);
+    return timebase.read();
 }
 
 pub const BytecodeThunk = struct {
@@ -827,4 +821,13 @@ test "thunk: reset wakes waiters and lets them retry" {
         .claimed => {},
         else => return error.ExpectedClaimedAfterReset,
     }
+}
+
+test "the created-tsc probe follows the build flag on every supported arch" {
+    if (!build_options.prof_main) return error.SkipZigTest;
+    if (!timebase.supported) return error.SkipZigTest;
+    try std.testing.expect(created_tsc_enabled);
+    // `CreatedTsc` is `void` while the gate is off, so the value check must
+    // not be analyzed in that state.
+    if (comptime created_tsc_enabled) try std.testing.expect(nowCreatedTsc() != 0);
 }


### PR DESCRIPTION
Adds a method to profiling on aarch64-linux systems. On an Ampere Altra M128-26, I get results like these:
```
prof: force_value:         calls=52500008  avg_excl=0.307  avg_ns=12.3
prof: make_bytecode_thunk: calls=3000001   avg_excl=0.887  avg_ns=35.5
prof: call_value:          calls=9000000   avg_excl=1.156  avg_ns=46.2
prof: force_thunk_slow:    calls=6000001   avg_excl=2.841  avg_ns=113.7
prof: run_isolated_frame:  calls=9000001   avg_excl=3.363  avg_ns=134.5
```

I didn't use the PMU registers as those require a sysctl to gain access in user space. The counter we're relying on is 25MHz but good enough for the use case.

In the future, I might tackle RISC-V support but this is at least the first step into decent profiling for me to do JIT properly.