### PR TITLE
scanner: accept leading-dot relative paths (`.devops/...`)

### DIFF
--- a/docs/syntax/nix-syntax.md
+++ b/docs/syntax/nix-syntax.md
@@ -23,7 +23,7 @@ String literal extent-finding lives in `string_syntax`; the [scanner](parsing.md
 
 Three path forms, all emitted as single tokens:
 
-- **Literal path** — `./foo`, `/abs/path`, `../x`. The scanner extends the token with `isPathContinue` over the allowed path bytes — ASCII letters, digits, and `/ . - _ +`; every path literal contains a `/` (the scanner only starts one at `./`, `../`, or a leading `/`).
+- **Literal path** — `./foo`, `/abs/path`, `../x`, and hidden-dir relatives like `.devops/nix/scope.nix`. The scanner matches Nix flex `PATH` (`PATH_CHAR*(\/PATH_CHAR+)+` with `PATH_CHAR = [A-Za-z0-9._+-]`), extended with `isPathContinue` over the allowed path bytes — ASCII letters, digits, and `/ . - _ +`. Every path literal contains a `/`; a bare `.name` without a slash segment is not a path.
 - **Interpolated path** — `./${v}/f`. Despite the embedded `${...}`, this is *one* `path` token: `findInterpolationEnd` skips over the interpolation while continuing the path scan, so the whole thing is a single literal with holes (like a string).
 - **Search path** — `<nixpkgs>`, `<nixpkgs/lib>`. Emitted as a distinct `search_path` token/atom; resolution against the search path happens later. `<` with no closing `>` is not a search path — the scanner backtracks to the bare `less` operator (see [parsing](parsing.md)).
 

--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -239,9 +239,9 @@ pub const Session = struct {
             .timeline_path = options.timeline_path,
         };
         if (options.timeline_path != null) {
-            // Event budget: 8M slots (~6M primary + ~2M steal flows). Was 2M;
-            // multi-worker NixOS evals filled that and dropped later samples.
-            session.timeline = try Timeline.init(allocator, ev.workerCount(), 1 << 23, ev.internTable());
+            // Event budget: 32M slots (~16M primary + ~16M steal flows at 1/2
+            // split). Desktop evals still dropped ~1.5M flows at 8M/¼.
+            session.timeline = try Timeline.init(allocator, ev.workerCount(), 1 << 25, ev.internTable());
             session.timeline.?.setFlows(options.timeline_flows);
             session.timeline.?.setSource(source);
             ev.setTraceFlows(options.timeline_flows);

--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -239,7 +239,9 @@ pub const Session = struct {
             .timeline_path = options.timeline_path,
         };
         if (options.timeline_path != null) {
-            session.timeline = try Timeline.init(allocator, ev.workerCount(), 1 << 21, ev.internTable());
+            // Event budget: 8M slots (~6M primary + ~2M steal flows). Was 2M;
+            // multi-worker NixOS evals filled that and dropped later samples.
+            session.timeline = try Timeline.init(allocator, ev.workerCount(), 1 << 23, ev.internTable());
             session.timeline.?.setFlows(options.timeline_flows);
             session.timeline.?.setSource(source);
             ev.setTraceFlows(options.timeline_flows);

--- a/src/expr/probe/timeline.zig
+++ b/src/expr/probe/timeline.zig
@@ -12,7 +12,10 @@ const InternTable = @import("runtime").intern.InternTable;
 
 const event_chunk_len = 256;
 const name_chunk_len = 16 << 10;
-const name_capacity = 16 << 20;
+// Subject labels + counter/span args share one arena. Desktop NixOS timelines
+// burn the old 16 MiB pool in a few seconds (empty `rss_mb` args thereafter).
+// 128 MiB keeps full-system evals labeled without growing on the hot path.
+const name_capacity = 128 << 20;
 const no_chunk = std.math.maxInt(u32);
 const full_chunk = no_chunk - 1;
 

--- a/src/expr/probe/timeline.zig
+++ b/src/expr/probe/timeline.zig
@@ -12,10 +12,10 @@ const InternTable = @import("runtime").intern.InternTable;
 
 const event_chunk_len = 256;
 const name_chunk_len = 16 << 10;
-// Subject labels + counter/span args share one arena. Desktop NixOS timelines
-// burn the old 16 MiB pool in a few seconds (empty `rss_mb` args thereafter).
-// 128 MiB keeps full-system evals labeled without growing on the hot path.
-const name_capacity = 128 << 20;
+// Subject labels + counter/span args share one arena. Full-system NixOS
+// timelines with many workers still exhaust 128 MiB (hundreds of thousands
+// of dropped_names); 512 MiB is preallocated only when --timeline is on.
+const name_capacity = 512 << 20;
 const no_chunk = std.math.maxInt(u32);
 const full_chunk = no_chunk - 1;
 
@@ -99,8 +99,9 @@ pub const Recorder = struct {
     active: bool = true,
 
     pub fn init(allocator: std.mem.Allocator, worker_count: usize, event_cap: usize, intern: *const InternTable) !Recorder {
-        // Protect 3/4 for primary events; compact flows use the remaining 1/4.
-        const flow_cap = event_cap / 4;
+        // Half of the budget for steal-flow arrows: multi-worker NixOS evals
+        // generate millions of steals and used to drop >1M flows with a 1/4 split.
+        const flow_cap = event_cap / 2;
         const primary_cap = event_cap - flow_cap;
         const worker_event_cap = chunkedPrefix(primary_cap, event_chunk_len);
 

--- a/src/syntax/scanner.zig
+++ b/src/syntax/scanner.zig
@@ -124,7 +124,14 @@ pub const Scanner = struct {
         if (isDigit(c)) return self.lexNumber(start);
         if (c == '"') return self.lexString(start, .double_quoted);
         if (c == '\'' and self.peek() == '\'') return self.lexString(start, .indented);
-        if (c == '.' and (self.peek() == '/' or (self.peek() == '.' and self.peekAhead(1) == '/'))) return self.lexPath(start);
+        // Relative path starting with `.` — Nix flex PATH form
+        // `{PATH_CHAR}*(\/{PATH_CHAR}+)+`, where PATH_CHAR is
+        // `[A-Za-z0-9._+-]` (no slash). Covers `./foo`, `../bar`, hidden
+        // dirs like `.devops/nix/scope.nix` (llama.cpp's flake), `.../x`,
+        // and `.5/foo` (path outranks a leading-dot float when a `/`
+        // segment follows). Bare `.devops` or `...` without a `/` segment
+        // is not a path.
+        if (c == '.' and self.looksLikeRelativePath()) return self.lexPath(start);
         // Leading-dot float: `.5`, `.5e3` (Nix's `0?\.[0-9]+` form). Deprecated
         // in Lix but still valid; `.` followed by a digit is never a selector
         // here because a bare `.` cannot start a select.
@@ -454,6 +461,28 @@ pub const Scanner = struct {
         return hasClass(c, char_path_continue);
     }
 
+    /// True when the token starting at the already-consumed `.` is a Nix
+    /// relative path (flex `PATH`), not a bare select `.`, ellipsis, or
+    /// leading-dot float. Peek-only: does not advance `self.pos`.
+    ///
+    /// Matches `{PATH_CHAR}*(\/{PATH_CHAR}+)+` with `PATH_CHAR = [A-Za-z0-9._+-]`,
+    /// also allowing `/${` as an interpolated segment opener after the slash.
+    fn looksLikeRelativePath(self: *Scanner) bool {
+        var i = self.pos;
+        // PATH_CHAR* (no slash)
+        while (i < self.source.len and isPathChar(self.source[i])) : (i += 1) {}
+        // Need at least one /PATH_CHAR+ (or /${) segment
+        if (i >= self.source.len or self.source[i] != '/') return false;
+        const c = if (i + 1 < self.source.len) self.source[i + 1] else 0;
+        if (c == '$' and i + 2 < self.source.len and self.source[i + 2] == '{') return true;
+        return c != 0 and isPathChar(c);
+    }
+
+    /// Nix flex `PATH_CHAR`: path segment bytes excluding `/`.
+    fn isPathChar(c: u8) bool {
+        return isAlpha(c) or isDigit(c) or c == '.' or c == '_' or c == '-' or c == '+';
+    }
+
     /// True when `self.pos` sits at a `/` that opens a further path segment,
     /// i.e. the slash abuts a segment char (`[A-Za-z0-9._+-]`, never another
     /// `/`) or a `${` interpolation. After an initial run of path chars — an
@@ -574,6 +603,51 @@ test "scanner recognizes simple path literals" {
     try std.testing.expectEqual(TokenType.path, scanner.next().type);
     try std.testing.expectEqual(TokenType.path, scanner.next().type);
     try std.testing.expectEqual(TokenType.eof, scanner.next().type);
+}
+
+// Hidden-dir relative paths (`.devops/...`) are valid Nix PATH tokens — used
+// by llama.cpp's flake (`callPackage .devops/nix/scope.nix`). Regression for
+// scanners that only started paths at `./` / `../`.
+test "scanner recognizes leading-dot hidden directory paths" {
+    var scanner = Scanner.init(".devops/nix/scope.nix .devops/nix/nixpkgs-instances.nix");
+
+    const t1 = scanner.next();
+    try std.testing.expectEqual(TokenType.path, t1.type);
+    try std.testing.expectEqualStrings(".devops/nix/scope.nix", scanner.source[t1.offset..][0..t1.len]);
+    const t2 = scanner.next();
+    try std.testing.expectEqual(TokenType.path, t2.type);
+    try std.testing.expectEqualStrings(".devops/nix/nixpkgs-instances.nix", scanner.source[t2.offset..][0..t2.len]);
+    try std.testing.expectEqual(TokenType.eof, scanner.next().type);
+}
+
+test "scanner: bare leading-dot name is not a path" {
+    // No `/` segment → not flex PATH; bare `.` then identifier (Nix errors at parse).
+    var scanner = Scanner.init(".devops");
+
+    try std.testing.expectEqual(TokenType.dot, scanner.next().type);
+    try std.testing.expectEqual(TokenType.identifier, scanner.next().type);
+    try std.testing.expectEqual(TokenType.eof, scanner.next().type);
+}
+
+test "scanner: leading-dot float still works; slash promotes to path" {
+    var floats = Scanner.init(".5 .5e3");
+    try std.testing.expectEqual(TokenType.float_val, floats.next().type);
+    try std.testing.expectEqual(TokenType.float_val, floats.next().type);
+    try std.testing.expectEqual(TokenType.eof, floats.next().type);
+
+    var path = Scanner.init(".5/foo");
+    try std.testing.expectEqual(TokenType.path, path.next().type);
+    try std.testing.expectEqual(TokenType.eof, path.next().type);
+}
+
+test "scanner: ellipsis is not a path unless a slash segment follows" {
+    var ell = Scanner.init("... ");
+    try std.testing.expectEqual(TokenType.ellipsis, ell.next().type);
+
+    var p = Scanner.init(".../x ...foo/bar");
+    try std.testing.expectEqual(TokenType.path, p.next().type);
+    try std.testing.expectEqual(TokenType.path, p.next().type);
+    try std.testing.expectEqual(TokenType.eof, p.next().type);
 }
 
 test "scanner recognizes interpolated path literals" {


### PR DESCRIPTION
This was broken

```
martin@nixos ~/p/compute (main) [1]> fix eval --extra-experimental-features 'flakes fetch-tree' --flake 'github:ggml-org/llama.cpp/b9190#packages'
[      22ms] [fetch] cached https://codeload.github.com/ggml-org/llama.cpp/tar.gz/b9190
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:79:11: Unexpected token '.'.
  79 |           .devops/nix/nixpkgs-instances.nix
     |           ^ near `.`
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:105:32: Unexpected token '='.
 105 |         flake.overlays.default = (
     |                                ^ near `=`
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:107:48: Unexpected token 'devops/nix/scope.nix'.
 107 |             llamaPackages = final.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
     |                                                ^^^^^^^^^^^^^^^^^^^^ near `devops/nix/scope.nix`
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:107:94: Unexpected token ';'.
 107 |             llamaPackages = final.callPackage .devops/nix/scope.nix { inherit llamaVersion; };
     |                                                                                              ^ near `;`
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:117:10: Unexpected token ';'.
 117 |         ];
     |          ^ near `;`
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:128:12: Unexpected token ':'.
 128 |           }:
     |            ^ near `:`
error: parse error at /home/martin/.cache/fix/tarball/307162bf02bf25f39d8f87ad3b5f2925/source/flake.nix:120:11: Expected '=' after attribute name.
 120 |           {
     |           ^ near `{`
martin@nixos ~/p/compute (main) [1]>
```

now it works

```
martin@nixos ~/p/compute (main) [1]> fix eval --impure --extra-experimental-features 'flakes fetch-tree' --flake 'github:ggml-org/llama.cpp/b9190#packages'
[      18ms] [fetch] cached https://codeload.github.com/ggml-org/llama.cpp/tar.gz/b9190
[      20ms] [fetch] cached https://codeload.github.com/hercules-ci/flake-parts/tar.gz/427bf4bd9435fdf21321c8cc628c24efc14c0f7a
[      22ms] [fetch] cached https://codeload.github.com/nix-community/nixpkgs.lib/tar.gz/92590dc744108b058000deae4b734f0aa5c33f50
{ aarch64-darwin = <CODE>; aarch64-linux = <CODE>; x86_64-darwin = <CODE>; x86_64-linux = <CODE>; }
```

grok wrote the code, it's probably slop, the purpose here is to illustrate the problem not to serve as a fix. please take over the PR