### PR TITLE
regex: treat `\` as literal inside character classes (POSIX ERE)

### DIFF
--- a/src/cli/progress.zig
+++ b/src/cli/progress.zig
@@ -239,7 +239,9 @@ pub const Session = struct {
             .timeline_path = options.timeline_path,
         };
         if (options.timeline_path != null) {
-            session.timeline = try Timeline.init(allocator, ev.workerCount(), 1 << 21, ev.internTable());
+            // Event budget: 8M slots (~6M primary + ~2M steal flows). Was 2M;
+            // multi-worker NixOS evals filled that and dropped later samples.
+            session.timeline = try Timeline.init(allocator, ev.workerCount(), 1 << 23, ev.internTable());
             session.timeline.?.setFlows(options.timeline_flows);
             session.timeline.?.setSource(source);
             ev.setTraceFlows(options.timeline_flows);

--- a/src/expr/probe/timeline.zig
+++ b/src/expr/probe/timeline.zig
@@ -12,7 +12,10 @@ const InternTable = @import("runtime").intern.InternTable;
 
 const event_chunk_len = 256;
 const name_chunk_len = 16 << 10;
-const name_capacity = 16 << 20;
+// Subject labels + counter/span args share one arena. Desktop NixOS timelines
+// burn the old 16 MiB pool in a few seconds (empty `rss_mb` args thereafter).
+// 128 MiB keeps full-system evals labeled without growing on the hot path.
+const name_capacity = 128 << 20;
 const no_chunk = std.math.maxInt(u32);
 const full_chunk = no_chunk - 1;
 

--- a/src/expr/support/regex.zig
+++ b/src/expr/support/regex.zig
@@ -351,12 +351,15 @@ const Parser = struct {
         return self.advance();
     }
 
+    /// Next byte of a bracket expression body.
+    ///
+    /// POSIX ERE: inside `[...]`, `.` `*` `[` and `\` lose their special
+    /// meaning — a backslash is a literal class member, not an escape.
+    /// (Nix `builtins.match` follows this; PCRE-style `[\-]` → only `-`
+    /// would reject systemd unit names that embed `\xNN` escapes, e.g.
+    /// nixpkgs wireguard peer units ending in `\x3d` for base64 `=`.)
     fn classByte(self: *Parser) anyerror!u8 {
         if (self.atEnd()) return error.InvalidRegex;
-        if (self.peek() == '\\') {
-            self.index += 1;
-            return self.escapedByte();
-        }
         return self.advance();
     }
 
@@ -602,4 +605,36 @@ test "regex supports posix classes alternation and search" {
     const hostname = (try hostname_pattern.matchFull(std.testing.allocator, "nixos")).?;
     defer hostname.deinit(std.testing.allocator);
     try std.testing.expectEqualStrings("ixos", hostname.captures[0].?);
+}
+
+// POSIX bracket expressions treat `\` as a literal member. The class `[\-]`
+// therefore matches both backslash and hyphen — matching Nix `builtins.match`
+// and the nixpkgs `unitNameType` pattern, which must accept unit names that
+// embed systemd escapes such as `\x3d` for `=`.
+test "regex char class treats backslash as literal (POSIX ERE)" {
+    var slash_hyphen = try Pattern.compile(std.testing.allocator, "[\\-]+");
+    defer slash_hyphen.deinit();
+
+    const only_bs = (try slash_hyphen.matchFull(std.testing.allocator, "\\")).?;
+    defer only_bs.deinit(std.testing.allocator);
+    const only_hyphen = (try slash_hyphen.matchFull(std.testing.allocator, "-")).?;
+    defer only_hyphen.deinit(std.testing.allocator);
+    const both = (try slash_hyphen.matchFull(std.testing.allocator, "\\-\\")).?;
+    defer both.deinit(std.testing.allocator);
+    try std.testing.expect((try slash_hyphen.matchFull(std.testing.allocator, "a")) == null);
+
+    // nixpkgs nixos/lib/systemd-lib.nix unitNameType (pattern text as the
+    // Nix string produces it after `\\` → `\`).
+    const unit_pat = "[a-zA-Z0-9@%:_.\\-]+[.](service|socket|device|mount|automount|swap|target|path|timer|scope|slice)";
+    var unit = try Pattern.compile(std.testing.allocator, unit_pat);
+    defer unit.deinit();
+
+    // Minimal repro: wireguard peer unit with trailing base64 `=` escaped as `\x3d`.
+    const peer = "wireguard-mullvad0-peer-q8TC-ILZWlaydPdkJLkL-pWB8qrK0dWkKtZMGqEElh8\\x3d.service";
+    const peer_match = (try unit.matchFull(std.testing.allocator, peer)).?;
+    defer peer_match.deinit(std.testing.allocator);
+    try std.testing.expectEqualStrings("service", peer_match.captures[0].?);
+
+    const plain = (try unit.matchFull(std.testing.allocator, "sshd.service")).?;
+    defer plain.deinit(std.testing.allocator);
 }


### PR DESCRIPTION
this is busted

expected
```
nix-repl> builtins.match "[\\-]+" "\\"
[ ]
```

actual
```
fix> builtins.match "[\\-]+" "\\"
null
```

it supposed to match because the `\\` turns into a `\` and is part of the character class. fix match impl doesn't understand

according to grok (patch might be slop feel free to adopt / close)

> Nix `builtins.match` follows POSIX ERE, where inside a bracket expression the backslash loses its special meaning and is a normal class member. fix previously treated `\` as an escape inside `[...]`, so a class written `[\-]` (as in nixpkgs `unitNameType`) only matched hyphen — not backslash.

the `\x3d` comes from here https://github.com/NixOS/nixpkgs/blob/32a4e87942101f1c9f9865e04dc3ddb175f5f32e/nixos/modules/services/networking/wireguard.nix#L262 (looks like this `wireguard-mullvad0-peer-q8TC-ILZWlaydPdkJLkL-pWB8qrK0dWkKtZMGqEElh8\\x3d.service`) then gets matched here https://github.com/NixOS/nixpkgs/blob/32a4e87942101f1c9f9865e04dc3ddb175f5f32e/nixos/lib/systemd-lib.nix#L70