### PR TITLE
fix: accumulating foldl' exhausts the byte store (OutOfMemory)

### DIFF
--- a/src/base/segments.zig
+++ b/src/base/segments.zig
@@ -92,6 +92,21 @@ pub fn StableSegments(comptime T: type, comptime params_in: anytype, comptime Vm
         pub const first_segment_size = params.first_segment_size;
         const first_log2: u6 = std.math.log2_int(u32, params.first_segment_size);
 
+        /// Total addressable slots. `segmentCapacity`/`segmentStart` are u32,
+        /// so the geometry tops out where `first_segment_size << segment`
+        /// stops fitting — NOT at `segment_count` (which for the byte store
+        /// nominally allows 28 segments but is unreachable past 16). Past
+        /// that point `segmentCapacity` truncates to 0 and every reservation
+        /// fails with `error.OutOfMemory`, so callers that must collect
+        /// before the store dies need this number, not the segment count.
+        pub const capacity_slots: u32 = blk: {
+            var seg: u32 = 0;
+            while (seg < segment_count and
+                (@as(u64, params.first_segment_size) << @intCast(seg)) <= std.math.maxInt(u32)) : (seg += 1)
+            {}
+            break :blk @intCast((@as(u64, params.first_segment_size) << @intCast(seg)) - params.first_segment_size);
+        };
+
         pub const Range = struct {
             segment: u32,
             offset: u32,
@@ -1187,4 +1202,27 @@ test "flat store: concurrent reserves are race-free" {
         try seen.put(v, {});
     }
     try std.testing.expectEqual(@as(usize, worker_count * per_worker), seen.count());
+}
+
+test "stable segments: capacity_slots is the reachable ceiling, not segment_count" {
+    // `segmentCapacity` computes `first_segment_size << segment` in u32, and
+    // Zig's `<<` truncates silently in every build mode. A store whose
+    // nominal `segment_count` runs past that point can never use the extra
+    // segments: `segmentCapacity` returns 0 there and every reservation
+    // fails with error.OutOfMemory. `capacity_slots` reports where the
+    // geometry actually stops.
+    const Bytes = StableSegments(u8, .{ .first_segment_size = 65536, .segment_count = 28 }, TestVma);
+    // 2^16 * (2^16 - 1): segments 0..15 are usable, 16..27 are unreachable.
+    try std.testing.expectEqual(@as(u32, 4294901760), Bytes.capacity_slots);
+    // Below maxInt(u32) — callers use that value as a sentinel.
+    try std.testing.expect(Bytes.capacity_slots < std.math.maxInt(u32));
+
+    // A store whose segment_count stops before the overflow keeps its
+    // nominal geometry.
+    const Small = StableSegments(u8, .{ .first_segment_size = 65536, .segment_count = 4 }, TestVma);
+    try std.testing.expectEqual(@as(u32, 65536 * 15), Small.capacity_slots);
+
+    // Wider elements hit the u32 id ceiling later (in slots, not bytes).
+    const Vals = StableSegments(u64, .{ .first_segment_size = 8192, .segment_count = 28 }, TestVma);
+    try std.testing.expectEqual(@as(u32, 8192 * ((1 << 19) - 1)), Vals.capacity_slots);
 }

--- a/src/expr/eval/tests/lists.zig
+++ b/src/expr/eval/tests/lists.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const std_testing = std.testing;
 const renderForTest = @import("../test_helpers.zig").renderForTest;
+const Engine = @import("../../evaluator.zig").Engine;
 
 test "length head and tail reject non-list arguments" {
     try std_testing.expectError(error.TypeError, renderForTest("builtins.length 1"));
@@ -130,4 +131,36 @@ test "foldl' on an empty list returns the seed without calling the operator" {
     const result = try renderForTest("builtins.foldl' (a: b: builtins.throw \"boom\") 5 [ ]");
     defer std_testing.allocator.free(result);
     try std_testing.expectEqualStrings("5", result);
+}
+
+test "an accumulating foldl' reclaims its intermediates" {
+    // Regression (evalbench string_concat / concat_sep_fold, both OutOfMemory):
+    // `builtinFoldlStrict` opened ONE root scope around the whole loop and
+    // called `rootKeep(acc)` per iteration. `rootKeep` only appends, so every
+    // intermediate accumulator stayed a GC root for the entire fold and the
+    // byte store grew as O(n^2) until its u32 id space (~4 GiB) ran out.
+    //
+    // Two more links had to hold for the reclaim to happen at all: the loop
+    // must reach a GC safepoint (the strict fan-out resolves the list up
+    // front, so nothing in the loop enters `forceThunkImpl`), and the byte
+    // store must defend its own ceiling rather than the RAM-derived line
+    // sitting above it.
+    //
+    // 30000 steps of a 1-byte-per-step fold allocate ~560 MB of intermediate
+    // text; only the last 30 KB is live.
+    var ev = try Engine.init(std_testing.allocator, .{ .worker_count = 0 });
+    defer ev.deinit();
+    ev.configureMemory(4 << 20, null, false); // tiny budget: collect early
+
+    const result = try ev.evaluate(
+        "builtins.stringLength (builtins.foldl' (a: b: a + b) \"\" (builtins.genList (i: \"x\") 30000))",
+    );
+    var out: std.Io.Writer.Allocating = .init(std_testing.allocator);
+    defer out.deinit();
+    try ev.writeValue(&out.writer, result);
+    try std_testing.expectEqualStrings("30000", out.written());
+
+    // ~197 MB reclaiming; 565 MB with the intermediates pinned (identical to
+    // `--gc-budget 0`, since before the fix collection freed none of them).
+    try std_testing.expect(ev.heap.counts().bytes < 400 << 20);
 }

--- a/src/expr/vm/builtins/lists.zig
+++ b/src/expr/vm/builtins/lists.zig
@@ -542,9 +542,24 @@ pub fn builtinFoldlStrict(self: *VM, op_arg: Value, nul_arg: Value, list_arg: Va
     const n = items.len;
     var i: usize = 0;
     while (i < n) : (i += 1) {
+        // The list's elements are usually already resolved (the fan-out
+        // above), so nothing in this loop reaches the forceThunk safepoint.
+        // Poll here or a pending collection never runs. Amortized: the
+        // unconditional call cost ~9ns/step (measured +9% on a 1M-step
+        // arithmetic fold), and a 64-step delay to the safepoint is
+        // negligible against the collector's 128 MB threshold step.
+        if (i & 63 == 0) vm_force.pollLoopSafepoint(self, acc);
         const item = try self.heap.getListItem(list_id, i);
         const partial = try vm_closures.callValue(self, op, acc);
-        acc = try vm_force.forceValue(self, try vm_closures.callValue(self, partial, item));
+        const next = try vm_force.forceValue(self, try vm_closures.callValue(self, partial, item));
+        // Only the LATEST accumulator is live. Drop the previous iteration's
+        // root before adding this one: `rootKeep` only appends, so rooting
+        // per iteration without this truncation pins every intermediate for
+        // the whole fold — a growing accumulator then holds O(n²) bytes live.
+        // No allocation or safepoint separates the truncation from the
+        // re-root, so `next` is never unrooted across a collection.
+        vm_force.rootsEnd(self, gc_roots);
+        acc = next;
         vm_force.rootKeep(self, acc);
     }
 

--- a/src/expr/vm/force.zig
+++ b/src/expr/vm/force.zig
@@ -1004,6 +1004,16 @@ fn waitForBusyThunk(self: *VM, thunk: *Thunk, thunk_id: types.ObjectId, demand: 
     wait_span.finish(.{});
 }
 
+/// Safepoint for a NATIVE builtin loop. `forceThunkImpl` is otherwise the
+/// only poll site, so a loop that allocates without forcing an unresolved
+/// thunk — `foldl'` over a list the strict fan-out already resolved is the
+/// canonical case — runs to completion with the collection request pending
+/// and the heap growing unbounded. `keep` is the loop-carried value the
+/// collector must see (it may be off the VM stack).
+pub fn pollLoopSafepoint(self: *VM, keep: Value) void {
+    pollForCollection(self, keep, true);
+}
+
 /// Respond to or lead a collection at the force boundary. `thunk_val` may be
 /// off the VM stack, so `gc_roots.extra` keeps it visible while the world stops.
 fn pollForCollection(self: *VM, thunk_val: Value, demand: bool) void {

--- a/src/runtime/heap.zig
+++ b/src/runtime/heap.zig
@@ -182,6 +182,14 @@ const AttrPosStore = segments.StableSegments(AttrPosEntry, .{ .first_segment_siz
 /// physical memory per surviving shard and hide the footprint from RSS.
 const ByteStore = segments.StableSegments(u8, .{ .first_segment_size = byte_chunk_size, .vma_tag = .strbytes }, mem_tag.vma);
 
+/// Where the byte store's own collection line starts, and how far it rises
+/// per collection (see `HeapCollectionState.byte_threshold`). An eighth of
+/// capacity leaves small evals untouched; the step then buys ~28 more
+/// collection cycles before the store's hard ceiling, which is what an
+/// accumulating fold needs to finish inside a 4 GiB id space.
+const byte_line_start: u32 = ByteStore.capacity_slots / 8;
+const byte_line_step: u32 = ByteStore.capacity_slots / 32;
+
 pub var next_heap_token: std.atomic.Value(u64) = .init(1);
 
 pub const ValueRange = ValueStore.Range;
@@ -602,6 +610,15 @@ pub const HeapCollectionState = struct {
     /// mov on x86, TSan-clean).
     collect_requested: std.atomic.Value(bool) = .init(false),
     threshold_bytes: u64 = std.math.maxInt(u64),
+    /// The byte store's own rising collection line, in slots. Its u32 id
+    /// space caps it near 4 GiB — below a RAM-derived `threshold_bytes` on
+    /// any modern box — so a string-heavy eval would otherwise exhaust the
+    /// store with the collector still idle. Kept separate (rather than
+    /// lowering the shared line) so object-heavy evals keep their budget.
+    /// Rises after each collection like `threshold_bytes`: the cursor is
+    /// monotonic, so anchoring to the live set would collect every safepoint.
+    /// Armed only alongside a budget, so `--gc-budget 0` still never collects.
+    byte_threshold: u32 = std.math.maxInt(u32),
     step_bytes: u64 = 0,
     budget_bytes: u64 = 0,
     disable_reuse: bool = false,
@@ -1649,7 +1666,30 @@ pub const ObjectHeap = struct {
     /// (non-moving) collection to run at the next forceThunk safepoint — it marks
     /// live, promotes survivors in place, and frees dead ranges to the free lists.
     inline fn gcCheckThreshold(self: *ObjectHeap) void {
-        if (self.totalReservedBytes() >= self.collection.threshold_bytes) self.collection.collect_requested.store(true, .monotonic);
+        if (self.totalReservedBytes() >= self.collection.threshold_bytes or
+            self.bytes.count() >= self.collection.byte_threshold)
+            self.collection.collect_requested.store(true, .monotonic);
+    }
+
+    /// Raise the byte store's line past the current cursor after a
+    /// collection (or at arming), so one crossing does not re-request a
+    /// collection at every subsequent allocation.
+    pub fn gcRaiseByteLine(self: *ObjectHeap) void {
+        if (self.collection.byte_threshold == std.math.maxInt(u32)) return; // never-collect
+        // Clamp to capacity, do NOT let the saturating add reach
+        // maxInt(u32): that value is the never-collect sentinel, so a
+        // near-ceiling raise would silently disarm the line exactly where
+        // it is the only thing standing between the eval and the wall.
+        // `capacity_slots` is below maxInt by construction, so this holds.
+        self.collection.byte_threshold = @min(
+            ByteStore.capacity_slots,
+            @max(byte_line_start, self.bytes.count() +| byte_line_step),
+        );
+    }
+
+    /// Arm the byte store's line (see `HeapCollectionState.byte_threshold`).
+    pub fn gcArmByteLine(self: *ObjectHeap) void {
+        self.collection.byte_threshold = byte_line_start;
     }
 
     /// Register the collect callback. Fired at

--- a/src/runtime/heap/collector.zig
+++ b/src/runtime/heap/collector.zig
@@ -147,6 +147,7 @@ pub fn enableCollect(heap: *ObjectHeap, budget: u64, step_bytes: u64) void {
     heap.collection.budget_bytes = budget;
     // Collect after fresh reservations cross the configured threshold.
     heap.collection.threshold_bytes = if (step_bytes > 0) heap.totalReservedBytes() + step_bytes else budget;
+    heap.gcArmByteLine();
     // Validation path arms eagerly (bootstrap_end == the arming count, so the
     // pre-arming region is empty), but turn on constrained mode so the always-
     // on transient-root gates are exercised. `armTracking` enables root tracking.
@@ -190,6 +191,7 @@ pub fn enableBudget(heap: *ObjectHeap, budget: u64, root_always: bool) void {
     heap.collection.step_bytes = 0;
     heap.collection.budget_bytes = budget;
     heap.collection.threshold_bytes = armLineBytes(budget);
+    heap.gcArmByteLine();
     heap.collection.bootstrap_end = heap.objects.count();
     heap.collection.root_always = root_always;
     heap.collection.root_active = root_always;
@@ -231,6 +233,7 @@ pub fn armLazy(heap: *ObjectHeap) void {
     const budget = heap.collection.budget_bytes;
     const headroom = std.math.clamp(budget / 8, 64 << 20, ObjectHeap.gc_headroom);
     heap.collection.threshold_bytes = @max(budget, heap.totalReservedBytes() + headroom);
+    heap.gcRaiseByteLine();
 }
 
 /// Run a collection now via the registered callback (the evaluator's
@@ -263,6 +266,7 @@ pub fn afterCollect(heap: *ObjectHeap, live_bytes: u64) void {
         heap.totalReservedBytes() + heap.collection.step_bytes
     else
         @max(budget, heap.totalReservedBytes() + headroom);
+    heap.gcRaiseByteLine();
     heap.gcArmPoolMissCollection();
     // Invalidate all thread-local caches (thunk memo, attr IC, call IC)
     // that key on `token`. Current thunk-memo and attr-cache values were


### PR DESCRIPTION
> **This is an LLM draft.** The draft identifies the problem and shows how to
> reproduce it. The draft is not the final fix. Treat the diagnosis as the
> result, and treat the patch as a basis for the final fix. You can change the
> structure of the fix, the values of the threshold constants, and the interval
> of the safepoint poll.

# Fix OutOfMemory in long string folds

A fold over a long list of strings fails with `error.OutOfMemory`. Three
separate defects cause this failure, and a fix must correct all three.

## Problem

This expression fails with `error.OutOfMemory`:

```nix
builtins.foldl' (a: b: a + b) "" (builtins.genList (i: "x") 200000)
```

## Cause 1: the fold keeps every intermediate value

`builtinFoldlStrict` opens one root scope for the full loop. The function then
calls `rootKeep(acc)` in every iteration, and `rootKeep` appends a new entry to
the scope. Each accumulator therefore stays a root of the garbage collector
until the fold ends.

The fold creates O(n^2) bytes of string data. All of this data stays live, and
the garbage collector cannot free it.

Fix: truncate the root scope before each call to `rootKeep`.

## Cause 2: the loop reaches no safepoint

Only `forceThunkImpl` calls `pollForCollection`. The strict fan-out resolves the
full list before the loop starts. No iteration of the loop therefore calls
`forceThunkImpl`, and the garbage collector runs zero times at every budget.

Fix: add `pollLoopSafepoint` and call it every 64 steps.

## Cause 3: the collection threshold is above the maximum capacity

`segmentCapacity` calculates `first_segment_size << segment` as a `u32` value.
The Zig `<<` operator truncates the result and gives no warning. The byte store
therefore stops at 4 GiB minus 64 KiB, and segments 16 to 27 stay unreachable.

The code calculates the collection threshold from the quantity of system memory.
This threshold is above the limit of the byte store, so the garbage collector
never starts.

Fix: add `capacity_slots` and a threshold for the byte store that rises after
each collection. Keep this threshold separate from `threshold_bytes`, so that
evaluations with many objects keep their budget. Set the new threshold only
together with a budget, so that `--gc-budget 0` continues to prevent all
collections.

## Test conditions

All measurements use hyperfine with 2 warmup runs and 10 timed runs. No other
program runs on the test machine. The build mode is ReleaseFast. The machine is
an Apple Silicon system with 10 cores and 16 GB of memory. The reference tool is
`nix-instantiate` from Determinate Nix 3.21.8. In the tables below, fix is the
tool in this repository.

To measure the time, each workload W runs as `builtins.deepSeq (W) 0`. To verify
the result, each workload runs as
`builtins.hashString "sha256" (builtins.toJSON (W))`.

For the expression and the description of all 24 workloads, see the
[workload reference](https://gist.github.com/wyattgill9/73b3af05d6a2a82d299ce65ea3608ae4).

## Comparison of fix with nix-instantiate

The ratio column shows the time of `nix-instantiate` divided by the time of fix.
A ratio above 1.00 means that fix is faster.

| workload | kind | fix (ms) | nix (ms) | ratio |
| --- | --- | --- | --- | --- |
| int_arith_fold | math | 91.5 ± 1.3 | 191.8 ± 44.7 | 2.10 |
| tarai | laziness | 137.2 ± 1.2 | 325.6 ± 77.6 | 2.37 |
| call_recursion | recursion | 49.8 ± 0.5 | 197.0 ± 54.0 | 3.96 |
| let_scope | scope | 53.2 ± 0.5 | 105.8 ± 65.0 | 1.99 |
| with_scope | scope | 34.3 ± 0.6 | 97.0 ± 76.6 | 2.83 |
| list_map | lists | 33.0 ± 0.5 | 122.3 ± 65.6 | 3.70 |
| list_foldl_sum | lists | 73.9 ± 0.4 | 148.7 ± 83.4 | 2.01 |
| genlist_alloc | lists | 43.6 ± 0.7 | 152.5 ± 54.5 | 3.50 |
| list_concat_grow | lists | 248.6 ± 1.3 | 348.6 ± 105.5 | 1.40 |
| list_sort | lists | 44.0 ± 0.4 | 46.7 ± 0.4 | 1.06 |
| list_filter | lists | 65.0 ± 1.2 | 237.1 ± 78.4 | 3.65 |
| attrset_construct | attrsets | 37.7 ± 0.5 | 61.0 ± 4.9 | 1.62 |
| attrset_select | attrsets | 119.8 ± 1.7 | 105.6 ± 67.9 | 0.88 |
| attrset_update | attrsets | 27.5 ± 0.5 | 328.2 ± 30.1 | 11.91 |
| generic_closure | attrsets | 29.8 ± 0.5 | 117.5 ± 55.4 | 3.94 |
| string_concat | strings | 692.4 ± 2.8 | 997.0 ± 0.3 | 1.44 |
| concat_sep_fold | strings | 416.7 ± 3.5 | 550.3 ± 68.5 | 1.32 |
| map_string_interp | strings | 50.3 ± 0.8 | 115.1 ± 53.8 | 2.29 |
| replace_strings | strings | 34.5 ± 0.4 | 137.8 ± 81.1 | 4.00 |
| string_match | strings | 101.4 ± 1.0 | 171.2 ± 88.7 | 1.69 |
| substring | strings | 49.9 ± 3.4 | 139.3 ± 88.4 | 2.79 |
| to_json | builtins | 23.2 ± 0.6 | 93.3 ± 66.1 | 4.02 |
| hash_string | builtins | 32.2 ± 0.7 | 105.7 ± 66.5 | 3.28 |
| bitops | builtins | 70.6 ± 1.0 | 128.8 ± 61.1 | 1.82 |

On real workloads, the peak size of the byte store stays far below the new limit
of 512 MB:

```
nixos-desktop               0.7 MB
nixos-hm                    0.8 MB
hm-profile                  0.3 MB
nixpkgs-package-metadata    0.7 MB
string-heavy                5.3 MB
string-churn              144.0 MB
```

## Known limitation

The collector does not fully recover the memory of an accumulator that only
increases in size. Every range that the collector frees is smaller than the next
request. The step of the threshold in each cycle therefore limits the growth,
and the reuse of freed ranges does not. When memory is low, `string_concat`
becomes approximately 4 times slower, and `nix-instantiate` does not show this
behavior. This limitation is a separate problem.

The patch does not change the 4 GiB limit of the byte store. The patch only
makes the collector hold the byte store below that limit.

## Verification

- Differential test against the reference Nix over all of nixpkgs: 66,518 of
  66,518 results match, with 0 derivation mismatches, 0 null results, and 0
  one-sided results.
- `zig build test`: unit tests 88 + 514, end-to-end tests 117, failures 0.
- `zig build test -Ddebug-checks=true`, which enables the detector for the
  garbage collector: the same results, with 0 failures.
- `zig build test-lang`: lix 357 of 357, and snix 114 of 114. Two tests do not
  run, because the machine has no rootless user namespaces.
- `zig build test-bench-fixtures`: 18 of 18 agree with `nix-instantiate`.
- `zig build test-concurrency`: 20 of 20. `zig build stress-concurrency`: pass.
- `zig build check-static`: pass.
- ReleaseSafe build: both workloads give correct results and cause no safety
  trap.
- Detector build with 1, 2, 4, 8, and 16 workers, 3 repetitions each, and a
  budget of 8 MB: every run gives the same hash, and that hash equals the hash
  from the reference Nix.
- Configuration matrix for the garbage collector: `--gc-budget 0` still gives 0
  collections. The budgets 512m and 32g, and the variables `FIX_GC_STEP_MB`,
  `FIX_GC_ROOTS=1`, and `FIX_GC_NOREUSE=1`, all give correct results.

The fingerprints match the reference Nix: `string_concat` gives `21ffb925`, and
`concat_sep_fold` gives `fd077e17`.
