### PR TITLE
store: reuse drivers across execution detach

### DIFF
--- a/src/store/daemon/runtime.zig
+++ b/src/store/daemon/runtime.zig
@@ -64,6 +64,17 @@ pub const DaemonRuntime = struct {
         return self.driver();
     }
 
+    /// The daemon driver, once its pool is running. A client that detached this
+    /// runtime and attached it again reuses the started pool through this:
+    /// `configureDaemon` refuses to reconfigure a backend that has started, and
+    /// the pool it left running would otherwise be unreachable.
+    pub fn startedDriver(self: *DaemonRuntime) ?backend.Driver {
+        self.pool_mu.lock();
+        defer self.pool_mu.unlock();
+        if (!self.pool_started) return null;
+        return self.driver();
+    }
+
     /// Install the evaluator capability that parks fibers around daemon-pool
     /// work. Tests and non-evaluator callers leave this null and block instead.
     pub fn setExecutor(self: *DaemonRuntime, executor: ?daemon_execution.Executor) void {

--- a/src/store/realization/daemon_client.zig
+++ b/src/store/realization/daemon_client.zig
@@ -25,6 +25,7 @@ pub const Client = struct {
     active_driver: ?backend.Driver = null,
     backend_mu: sync.BlockingMutex = .{},
     backend_driver: ?backend.Driver = null,
+    backend_started: bool = false,
     test_owned_runtime: if (builtin.is_test) ?*DaemonRuntime else void = if (builtin.is_test) null else {},
 
     pub fn init(allocator: std.mem.Allocator) Client {
@@ -106,6 +107,7 @@ pub const Client = struct {
         if (self.active_driver != null) return error.BackendAlreadyStarted;
         if (self.backend_driver) |old| old.destroy();
         self.backend_driver = selected;
+        self.backend_started = false;
     }
 
     pub fn enableWrites(self: *Client) void {
@@ -123,6 +125,12 @@ pub const Client = struct {
         if (self.runtime) |runtime| runtime.setExecutor(null);
         self.pool_executor = null;
         self.runtime = null;
+        // `active_driver` is `ensureBackend`'s state, so drop it under its lock.
+        // Both kinds of driver stay started across this, and neither may be
+        // started twice: `backend_started` guards a selected driver, and the
+        // default daemon is recovered from its runtime by `startedDriver`.
+        self.backend_mu.lock();
+        defer self.backend_mu.unlock();
         self.active_driver = null;
     }
 
@@ -136,17 +144,34 @@ pub const Client = struct {
         self.backend_mu.lock();
         defer self.backend_mu.unlock();
         if (self.active_driver) |driver| return driver;
-        const driver = self.backend_driver orelse blk: {
-            const runtime = self.runtime orelse return error.StoreUnavailable;
-            const io = self.io orelse return error.StoreUnavailable;
-            break :blk try runtime.configureDaemon(
-                self.allocator,
-                io,
-                self.socket,
-                self.options,
-                self.writes_enabled,
-            );
-        };
+        if (self.backend_driver) |driver| {
+            // A driver's `start` is not idempotent (it spawns its worker set),
+            // and a selection outlives `clearExecution`, so start it at most
+            // once. The default daemon has its own guard in `configureDaemon`.
+            if (!self.backend_started) {
+                try driver.start();
+                self.backend_started = true;
+            }
+            self.active_driver = driver;
+            return driver;
+        }
+        const runtime = self.runtime orelse return error.StoreUnavailable;
+        // A runtime re-attached after `clearExecution` keeps the pool it already
+        // started, and its configuration was fixed at that first start, so take
+        // the running driver back rather than asking `configureDaemon` to
+        // reconfigure a started backend and refuse.
+        if (runtime.startedDriver()) |driver| {
+            self.active_driver = driver;
+            return driver;
+        }
+        const io = self.io orelse return error.StoreUnavailable;
+        const driver = try runtime.configureDaemon(
+            self.allocator,
+            io,
+            self.socket,
+            self.options,
+            self.writes_enabled,
+        );
         try driver.start();
         self.active_driver = driver;
         return driver;

--- a/src/store/realization/recipe_tests.zig
+++ b/src/store/realization/recipe_tests.zig
@@ -212,6 +212,53 @@ test "daemon worker spans bracket validity checks and store writes" {
     } else return error.MissingRecipeRealizationApi;
 }
 
+test "a daemon runtime re-attached after clearExecution keeps serving from its started pool" {
+    if (comptime realizationApiAvailable()) {
+        var fake = try FakeDaemon.start(std.testing.allocator, std.testing.io);
+        defer fake.deinit();
+        var store = RealizationStore.init(std.testing.allocator);
+        defer store.deinit();
+
+        // Held locally so the same runtime can be attached twice: the pool it
+        // starts here has to survive the detach in between.
+        store.setIo(std.testing.io);
+        store.testAccess().useBorrowedDaemonSocket(fake.socketPath());
+        const rt = try std.testing.allocator.create(DaemonRuntime);
+        rt.* = DaemonRuntime.init();
+        rt.pool_workers = 1;
+        store.testAccess().takeDaemonRuntime(rt);
+
+        try store.recordOwnedNarRecipe(dep_nar_path, try owned(std.testing.allocator, "nar payload"));
+        try store.ensureClosure(dep_nar_path);
+
+        store.clearExecution();
+        store.testAccess().takeDaemonRuntime(rt);
+
+        // Reconfiguring a started runtime is refused, so the second attach has
+        // to take the running driver back rather than ask for a new one.
+        try store.recordOwnedTextRecipe(dep_text_path, try owned(std.testing.allocator, "dependency"), &.{});
+        try store.ensureClosure(dep_text_path);
+    } else return error.MissingRecipeRealizationApi;
+}
+
+test "a selected store backend starts only once across clearExecution" {
+    if (comptime realizationApiAvailable()) {
+        var dummy = DummyStore.init(std.testing.allocator);
+        defer dummy.deinit();
+        var store = RealizationStore.init(std.testing.allocator);
+        defer store.deinit();
+        try attachDummy(&store, &dummy);
+
+        store.enableStoreWrites();
+        try std.testing.expectEqual(@as(usize, 1), dummy.startCount());
+
+        store.clearExecution();
+        try store.recordOwnedTextRecipe(dep_text_path, try owned(std.testing.allocator, "dependency"), &.{});
+        try store.ensureClosure(dep_text_path);
+        try std.testing.expectEqual(@as(usize, 1), dummy.startCount());
+    } else return error.MissingRecipeRealizationApi;
+}
+
 test "dummy backend realizes dependency closures through the store interface" {
     if (comptime realizationApiAvailable()) {
         var dummy = DummyStore.init(std.testing.allocator);

--- a/src/store/testing/dummy_store.zig
+++ b/src/store/testing/dummy_store.zig
@@ -15,6 +15,7 @@ pub const DummyStore = struct {
     objects: std.StringHashMapUnmanaged([]u8) = .empty,
     effects: std.ArrayListUnmanaged(Effect) = .empty,
     returned_path: ?[]u8 = null,
+    starts: usize = 0,
 
     pub const Kind = enum {
         check,
@@ -88,6 +89,12 @@ pub const DummyStore = struct {
         return count;
     }
 
+    pub fn startCount(self: *DummyStore) usize {
+        self.mu.lock();
+        defer self.mu.unlock();
+        return self.starts;
+    }
+
     pub fn effectsLen(self: *DummyStore) usize {
         self.mu.lock();
         defer self.mu.unlock();
@@ -134,7 +141,12 @@ pub const DummyStore = struct {
         return @ptrCast(@alignCast(raw));
     }
 
-    fn start(_: *anyopaque) !void {}
+    fn start(raw: *anyopaque) !void {
+        const self = selfFrom(raw);
+        self.mu.lock();
+        defer self.mu.unlock();
+        self.starts += 1;
+    }
 
     fn run(raw: *anyopaque, work: backend.WorkFn, context: *anyopaque) !void {
         work(raw, context);


### PR DESCRIPTION
## Summary

- start explicitly selected store drivers at most once across execution teardown
- recover an already-started daemon driver when its runtime is reattached
- synchronize active-driver clearing with backend selection
- add regressions for selected and daemon-backed stores

## Tests

- nix-shell --run "zig build test-store --summary all" (94 passed)